### PR TITLE
Add GitHub workflow for Homebrew tap auto-bump and contributing docs

### DIFF
--- a/.github/workflows/bump-tap.yml
+++ b/.github/workflows/bump-tap.yml
@@ -1,0 +1,68 @@
+name: Bump Homebrew Tap
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Prepare variables
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          echo "TAG=${TAG_NAME}" >> $GITHUB_ENV
+          echo "TARBALL=https://github.com/${{ github.repository }}/archive/refs/tags/${TAG_NAME}.tar.gz" >> $GITHUB_ENV
+
+      - name: Compute tarball sha256
+        run: |
+          curl -sL "$TARBALL" -o linctl.tgz
+          SHASUM=$(sha256sum linctl.tgz | awk '{print $1}')
+          echo "SHA256=$SHASUM" >> $GITHUB_ENV
+
+      - name: Clone tap repo and push branch
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -e
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          git clone https://github.com/dorkitude/homebrew-linctl.git
+          cd homebrew-linctl
+          BRANCH="bump-linctl-${TAG#v}"
+          git checkout -b "$BRANCH"
+          # Update Formula
+          sed -i.bak -E "s|url \"[^\"]+\"|url \"https://github.com/${{ github.repository }}/archive/refs/tags/${TAG}.tar.gz\"|g" Formula/linctl.rb
+          sed -i.bak -E "s|sha256 \"[0-9a-f]+\"|sha256 \"${SHA256}\"|g" Formula/linctl.rb
+          rm -f Formula/linctl.rb.bak
+          git add Formula/linctl.rb
+          git commit -m "linctl: bump to ${TAG}"
+          git push "https://${GH_TOKEN}@github.com/dorkitude/homebrew-linctl.git" HEAD:"$BRANCH"
+
+      - name: Open PR on tap repo
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          cd homebrew-linctl
+          BRANCH="bump-linctl-${TAG#v}"
+          gh pr create \
+            --title "linctl: bump to ${TAG}" \
+            --body "Update formula to ${TAG}." \
+            --base master \
+            --head "$BRANCH"
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to linctl
+
+Thanks for contributing! This repo aims to keep changes simple, focused, and tested.
+
+## Development
+
+- Requirements: Go 1.22+, `gh` CLI (optional), `jq` (for examples), `golangci-lint` (optional).
+- Useful targets:
+  - `make deps` — install/tidy deps
+  - `make build` — local build
+  - `make test` — smoke tests (read-only commands)
+  - `make lint` — lint if you have golangci-lint
+  - `make fmt` — go fmt
+
+## Release Checklist
+
+Follow this checklist to cut a new release and update Homebrew:
+
+1) Prepare
+- Ensure README and help text match behavior.
+- Run `make test` to verify smoke tests pass.
+- Optionally draft release notes (highlights, fixes, breaking changes).
+
+2) Tag and Release (vX.Y.Z)
+- Create tag and push:
+  ```bash
+  git tag vX.Y.Z -a -m "vX.Y.Z: short summary"
+  git push origin vX.Y.Z
+  ```
+- Create GitHub release (with notes):
+  ```bash
+  gh release create vX.Y.Z \
+    --title "linctl vX.Y.Z" \
+    --notes "<highlights/fixes>"
+  ```
+
+3) Homebrew Tap Bump (auto)
+- This repo has a GitHub Action that auto-opens a PR to the tap on release publish.
+- Required secret: `HOMEBREW_TAP_TOKEN` (fine‑grained PAT with contents:write on `dorkitude/homebrew-linctl`).
+  - Add in GitHub: repo Settings → Secrets and variables → Actions → New repository secret.
+
+4) Homebrew Tap Bump (manual fallback)
+If the action is disabled or no secret is configured:
+```bash
+TAG=vX.Y.Z
+TARBALL=https://github.com/dorkitude/linctl/archive/refs/tags/${TAG}.tar.gz
+curl -sL "$TARBALL" -o /tmp/linctl.tgz
+SHA=$(shasum -a 256 /tmp/linctl.tgz | awk '{print $1}')
+
+git clone https://github.com/dorkitude/homebrew-linctl.git
+cd homebrew-linctl
+git checkout -b bump-linctl-${TAG#v}
+sed -i.bak -E "s|url \"[^\"]+\"|url \"$TARBALL\"|g" Formula/linctl.rb
+sed -i.bak -E "s|sha256 \"[0-9a-f]+\"|sha256 \"$SHA\"|g" Formula/linctl.rb
+rm -f Formula/linctl.rb.bak
+git commit -am "linctl: bump to ${TAG}"
+git push -u origin HEAD
+gh pr create --title "linctl: bump to ${TAG}" --body "Update formula to ${TAG}." --base master --head bump-linctl-${TAG#v}
+```
+
+5) Validate
+- After the tap PR merges:
+  ```bash
+  brew update && brew upgrade linctl
+  linctl --version
+  linctl docs | head -n 5
+  ```
+- Run a quick smoke test against your Linear workspace if possible.
+
+6) Housekeeping
+- Close any issues tied to the release.
+- Start a new milestone if applicable.
+


### PR DESCRIPTION
- Add .github/workflows/bump-tap.yml to automatically create PR on homebrew-linctl repo when a release is published
- Add CONTRIBUTING.md with development guidelines and release checklist
- Workflow handles tarball SHA256 computation and formula updates

🤖 Generated with [Claude Code](https://claude.ai/code)