### PR TITLE
Handle system comments without author

### DIFF
--- a/cmd/comment.go
+++ b/cmd/comment.go
@@ -83,7 +83,7 @@ var commentListCmd = &cobra.Command{
 				if i > 0 {
 					fmt.Println("---")
 				}
-				fmt.Printf("Author: %s\n", comment.User.Name)
+				fmt.Printf("Author: %s\n", commentAuthorName(&comment))
 				fmt.Printf("Date: %s\n", comment.CreatedAt.Format("2006-01-02 15:04:05"))
 				fmt.Printf("Comment:\n%s\n", comment.Body)
 			}
@@ -109,7 +109,7 @@ var commentListCmd = &cobra.Command{
 				// Header with author and time
 				timeAgo := formatTimeAgo(comment.CreatedAt)
 				fmt.Printf("%s %s %s\n",
-					color.New(color.FgCyan, color.Bold).Sprint(comment.User.Name),
+					color.New(color.FgCyan, color.Bold).Sprint(commentAuthorName(&comment)),
 					color.New(color.FgWhite, color.Faint).Sprint("•"),
 					color.New(color.FgWhite, color.Faint).Sprint(timeAgo))
 
@@ -160,7 +160,7 @@ var commentCreateCmd = &cobra.Command{
 			output.JSON(comment)
 		} else if plaintext {
 			fmt.Printf("Created comment on %s\n", issueID)
-			fmt.Printf("Author: %s\n", comment.User.Name)
+			fmt.Printf("Author: %s\n", commentAuthorName(comment))
 			fmt.Printf("Date: %s\n", comment.CreatedAt.Format("2006-01-02 15:04:05"))
 		} else {
 			fmt.Printf("%s Added comment to %s\n",

--- a/cmd/comment_helpers.go
+++ b/cmd/comment_helpers.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/dorkitude/linctl/pkg/api"
+)
+
+func commentAuthorName(comment *api.Comment) string {
+	if comment == nil || comment.User == nil {
+		return "System"
+	}
+	if name := strings.TrimSpace(comment.User.Name); name != "" {
+		return name
+	}
+	if email := strings.TrimSpace(comment.User.Email); email != "" {
+		return email
+	}
+	return "System"
+}

--- a/cmd/issue.go
+++ b/cmd/issue.go
@@ -498,7 +498,7 @@ var issueGetCmd = &cobra.Command{
 			if issue.Comments != nil && len(issue.Comments.Nodes) > 0 {
 				fmt.Printf("\n## Recent Comments\n")
 				for _, comment := range issue.Comments.Nodes {
-					fmt.Printf("\n### %s - %s\n", comment.User.Name, comment.CreatedAt.Format("2006-01-02 15:04"))
+					fmt.Printf("\n### %s - %s\n", commentAuthorName(&comment), comment.CreatedAt.Format("2006-01-02 15:04"))
 					if comment.EditedAt != nil {
 						fmt.Printf("*(edited %s)*\n", comment.EditedAt.Format("2006-01-02 15:04"))
 					}
@@ -682,7 +682,7 @@ var issueGetCmd = &cobra.Command{
 			fmt.Printf("\n%s\n", color.New(color.FgYellow).Sprint("Recent Comments:"))
 			for _, comment := range issue.Comments.Nodes {
 				fmt.Printf("  💬 %s - %s\n",
-					color.New(color.FgCyan).Sprint(comment.User.Name),
+					color.New(color.FgCyan).Sprint(commentAuthorName(&comment)),
 					color.New(color.FgWhite, color.Faint).Sprint(comment.CreatedAt.Format("2006-01-02 15:04")))
 				// Show first line of comment
 				lines := strings.Split(comment.Body, "\n")


### PR DESCRIPTION
## Summary
- Guard nil `comment.user` and render system comments safely.

## Changes
1. Add `commentAuthorName` helper to fall back to "System" when `user` is nil/empty.
2. Use the helper in `comment` and `issue` command output paths.

## Test plan
- [x] `go build -o /tmp/linctl ./`
- [x] `/tmp/linctl comment list LOC-3812` (no crash; system comments render)
- [x] `/tmp/linctl issue get LOC-3812` (no crash; recent comments render)

Fixes #28