### PR TITLE
feat: add --content flag to project update

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ linctl project update <project-id> [flags]
   --start-date           YYYY-MM-DD or empty to clear
   --target-date          YYYY-MM-DD or empty to clear
   --color                Hex color
+  --content              Project document body content
 
 # Delete/archive project
 linctl project delete <project-id> [flags]

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -891,6 +891,11 @@ Examples:
 			input["color"] = colorValue
 		}
 
+		if cmd.Flags().Changed("content") {
+			content, _ := cmd.Flags().GetString("content")
+			input["content"] = content
+		}
+
 		// Check if any updates were specified
 		if len(input) == 0 {
 			output.Error("No updates specified. Use flags to specify what to update.", plaintext, jsonOut)
@@ -1051,6 +1056,7 @@ func init() {
 	projectUpdateCmd.Flags().String("start-date", "", "Start date (YYYY-MM-DD, or empty to remove)")
 	projectUpdateCmd.Flags().String("target-date", "", "Target date (YYYY-MM-DD, or empty to remove)")
 	projectUpdateCmd.Flags().String("color", "", "Project color (hex code)")
+	projectUpdateCmd.Flags().String("content", "", "Project document body content")
 
 	// Delete command flags
 	projectDeleteCmd.Flags().Bool("permanent", false, "Permanently delete (cannot be undone)")

--- a/cmd/project_cmd_test.go
+++ b/cmd/project_cmd_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func resetProjectUpdateFlags(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{"name", "description", "state", "lead", "start-date", "target-date", "color", "content"} {
+		flag := projectUpdateCmd.Flags().Lookup(name)
+		if flag == nil {
+			t.Fatalf("missing flag %q", name)
+		}
+		if err := flag.Value.Set(flag.DefValue); err != nil {
+			t.Fatalf("reset flag %q: %v", name, err)
+		}
+		flag.Changed = false
+	}
+}
+
+func TestProjectUpdateCmdContentFlag(t *testing.T) {
+	origTransport := http.DefaultTransport
+	defer func() { http.DefaultTransport = origTransport }()
+	t.Setenv("LINCTL_API_KEY", "test-key")
+	viper.Set("plaintext", true)
+	viper.Set("json", false)
+	resetProjectUpdateFlags(t)
+
+	var sawContent string
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq gqlCommandTestRequest
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("decode GraphQL request: %v", err)
+		}
+
+		if strings.Contains(gqlReq.Query, "mutation UpdateProject(") {
+			input, ok := gqlReq.Variables["input"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("expected input map, got %#v", gqlReq.Variables["input"])
+			}
+			if v, ok := input["content"].(string); ok {
+				sawContent = v
+			}
+			body := `{"data":{"projectUpdate":{"success":true,"project":{"id":"proj-1","name":"Test Project","description":"","content":"# Hello world","state":"started","progress":0.5,"startDate":null,"targetDate":null,"url":"https://linear.app/test/project/proj-1","icon":null,"color":"#000","createdAt":"2026-03-01T00:00:00Z","updatedAt":"2026-03-02T00:00:00Z","lead":null,"teams":{"nodes":[]}}}}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}
+
+		t.Fatalf("unexpected GraphQL operation: %s", gqlReq.Query)
+		return nil, nil
+	})
+
+	_ = projectUpdateCmd.Flags().Set("content", "# Hello world")
+	projectUpdateCmd.Run(projectUpdateCmd, []string{"proj-1"})
+
+	if sawContent != "# Hello world" {
+		t.Fatalf("expected content %q, got %q", "# Hello world", sawContent)
+	}
+}

--- a/pkg/api/queries.go
+++ b/pkg/api/queries.go
@@ -1342,6 +1342,7 @@ func (c *Client) UpdateProject(ctx context.Context, id string, input map[string]
 					id
 					name
 					description
+					content
 					state
 					progress
 					startDate

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -159,6 +159,7 @@ run_test "issue update --parent flag" "go run main.go issue update --help" "pare
 run_test "issue relation help" "go run main.go issue relation --help" "Manage relations between Linear issues"
 run_test "issue relation add help" "go run main.go issue relation add --help" "blocks"
 run_test "project help" "go run main.go project --help" "Available Commands:"
+run_test "project update --content flag" "go run main.go project update --help" "content"
 run_test "team help" "go run main.go team --help" "Available Commands:"
 run_test "user help" "go run main.go user --help" "Available Commands:"
 


### PR DESCRIPTION
## Summary
- Adds `--content` flag to `linctl project update` for editing the project document body
- Adds `content` to the `UpdateProject` GraphQL mutation response fields
- Includes unit test, smoke test, and README update

Closes #42

## Test plan
- [x] `go test ./...` passes
- [x] `linctl project update --help` shows `--content` flag
- [x] `bash smoke_test.sh` passes (47/47)
- [ ] Manual: `linctl project update <id> --content "# New content"` updates the project document

🤖 Generated with [Claude Code](https://claude.com/claude-code)