### PR TITLE
Add dynamic linctl mcp namespace with cached tool registry

### DIFF
--- a/Formula/linctl.rb
+++ b/Formula/linctl.rb
@@ -1,8 +1,8 @@
 class Linctl < Formula
   desc "Comprehensive command-line interface for Linear's API"
   homepage "https://github.com/dorkitude/linctl"
-  url "https://github.com/dorkitude/linctl/archive/refs/tags/v0.1.5.tar.gz"
-  sha256 "fddd9b17f07279663fa5f23e12e56b9f025064ba824a4c24c433ea8699affefb"
+  url "https://github.com/dorkitude/linctl/archive/refs/tags/v0.1.8.tar.gz"
+  sha256 "a54c291582acdf1a3b17d1dfe35c7e99998653952aeaa28bfcf3d22ff6d56345"
   license "MIT"
   head "https://github.com/dorkitude/linctl.git", branch: "master"
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A command-line interface for the Linear API, built with Go and Cobra.
 - **Comments**: list/get/create/update/delete.
 - **Agent Sessions**: inspect issue agent session state and mention delegated/active agents.
 - **Raw GraphQL**: execute arbitrary Linear GraphQL using your `linctl` auth context.
+- **Dynamic MCP namespace**: discover and call schema-backed operations via `linctl mcp`.
 - **Output modes**: table, plaintext, and JSON.
 - **Sorting and time filters**: reusable list/search filtering patterns.
 - **Built-in docs**: `linctl docs`.
@@ -302,6 +303,24 @@ linctl graphql --file query.graphql --variables-file vars.json
 cat query.graphql | linctl graphql --variables '{"k":"ENG"}'
 ```
 
+### 10. Dynamic MCP Tools (Schema-Driven)
+```bash
+# Sync cache from live schema introspection (12h TTL)
+linctl mcp sync
+
+# List cached dynamic tools
+linctl mcp tools
+
+# Call a tool (full name)
+linctl mcp call query.viewer
+
+# Call a mutation with JSON arguments
+linctl mcp call mutation.issueCreate --json '{"input":{"title":"Fix login","teamId":"team-id"}}'
+
+# Override selection set for object return types
+linctl mcp call query.issue --json '{"id":"LIN-123"}' --selection '{ id identifier title state { name } }'
+```
+
 ## Command Reference
 
 ### Global Flags
@@ -329,6 +348,22 @@ linctl graphql [query] [flags]
   -f, --file string            Path to a .graphql file
       --variables string       Variables as JSON object string
       --variables-file string  Path to JSON object file with variables
+```
+
+### MCP Commands
+```bash
+# Refresh cache of dynamic tools discovered from Linear schema
+linctl mcp sync
+
+# List cached tools (name, args, return type)
+linctl mcp tools
+
+# Call by full name (`query.*` or `mutation.*`)
+linctl mcp call <tool-name> [flags]
+
+# Flags:
+      --json string        JSON object of tool arguments
+      --selection string   Override selection set for object/interface/union return types
 ```
 
 ### Issue Commands

--- a/SKILL.md
+++ b/SKILL.md
@@ -52,6 +52,7 @@ Use this skill when the user wants to inspect or modify Linear data through `lin
 - Labels: `linctl label ...`
 - Agent Sessions: `linctl agent ...`
 - Auth: `linctl auth ...`
+- Dynamic MCP: `linctl mcp ...` (`sync`, `tools`, `call`)
 
 ## Suggested Read Patterns
 
@@ -76,6 +77,11 @@ linctl team state list <TEAM_KEY> --json
 
 # Agent session status for an issue
 linctl agent <ISSUE_ID> --json
+
+# Dynamic schema-backed tool list and call
+linctl mcp sync
+linctl mcp tools --json
+linctl mcp call query.viewer
 ```
 
 ## Suggested Write Patterns

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -1,0 +1,324 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dorkitude/linctl/pkg/api"
+	"github.com/dorkitude/linctl/pkg/auth"
+	"github.com/dorkitude/linctl/pkg/mcpcache"
+	"github.com/dorkitude/linctl/pkg/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const mcpCacheMaxAge = 12 * time.Hour
+
+var (
+	mcpCmd = &cobra.Command{
+		Use:   "mcp",
+		Short: "Dynamic GraphQL-backed Linear tooling",
+		Long: `Dynamic Linear capability surface generated from GraphQL introspection.
+
+Use this for newly added Linear features before first-class linctl commands exist.
+
+Examples:
+  linctl mcp sync
+  linctl mcp tools
+  linctl mcp call query.viewer
+  linctl mcp call mutation.issueCreate --json '{"input":{"title":"Test issue","teamId":"..."}}'`,
+	}
+	mcpSyncCmd = &cobra.Command{
+		Use:   "sync",
+		Short: "Refresh MCP tool registry cache",
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = args
+			quiet, _ := cmd.Flags().GetBool("quiet")
+			if err := runMCPSync(cmd, quiet); err != nil {
+				plaintext := viper.GetBool("plaintext")
+				jsonOut := viper.GetBool("json")
+				output.Error(err.Error(), plaintext, jsonOut)
+				os.Exit(1)
+			}
+		},
+	}
+	mcpToolsCmd = &cobra.Command{
+		Use:   "tools",
+		Short: "List cached MCP tools",
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = args
+			plaintext := viper.GetBool("plaintext")
+			jsonOut := viper.GetBool("json")
+
+			cache, err := mcpcache.Load()
+			if err != nil {
+				output.Error("MCP cache not found. Run 'linctl mcp sync' first.", plaintext, jsonOut)
+				os.Exit(1)
+			}
+
+			rows := make([][]string, 0, len(cache.Tools))
+			for _, tool := range cache.Tools {
+				rows = append(rows, []string{
+					tool.Name,
+					tool.Kind,
+					summarizeArgs(tool.Args),
+					tool.ReturnType,
+					summarizeDescription(tool.Description),
+				})
+			}
+			sort.Slice(rows, func(i, j int) bool { return rows[i][0] < rows[j][0] })
+
+			if jsonOut {
+				output.JSON(map[string]interface{}{
+					"fetched_at": cache.FetchedAt,
+					"ttl_hours":  int(mcpCacheMaxAge.Hours()),
+					"tools":      cache.Tools,
+				})
+				return
+			}
+
+			output.Table(output.TableData{
+				Headers: []string{"Name", "Kind", "Args", "Returns", "Description"},
+				Rows:    rows,
+			}, plaintext, jsonOut)
+
+			stale := mcpcache.IsStale(cache, mcpCacheMaxAge)
+			age := time.Since(cache.FetchedAt).Round(time.Minute)
+			if age < 0 {
+				age = 0
+			}
+			if stale {
+				output.Info(fmt.Sprintf("MCP cache is stale (%s old). Refresh with 'linctl mcp sync'.", age), plaintext, jsonOut)
+			} else {
+				output.Info(fmt.Sprintf("MCP cache age: %s (TTL %dh)", age, int(mcpCacheMaxAge.Hours())), plaintext, jsonOut)
+			}
+		},
+	}
+	mcpCallCmd = &cobra.Command{
+		Use:   "call <tool-name>",
+		Short: "Call a cached MCP tool by name",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			plaintext := viper.GetBool("plaintext")
+			jsonOut := viper.GetBool("json")
+
+			cache, err := mcpcache.Load()
+			if err != nil {
+				output.Error("MCP cache not found. Run 'linctl mcp sync' first.", plaintext, jsonOut)
+				os.Exit(1)
+			}
+
+			tool, err := resolveMCPTool(cache.Tools, args[0])
+			if err != nil {
+				output.Error(err.Error(), plaintext, jsonOut)
+				os.Exit(1)
+			}
+
+			argJSON, _ := cmd.Flags().GetString("json")
+			arguments, err := loadMCPArguments(argJSON)
+			if err != nil {
+				output.Error(err.Error(), plaintext, jsonOut)
+				os.Exit(1)
+			}
+
+			selection, _ := cmd.Flags().GetString("selection")
+			query, variables, err := api.BuildMCPCall(tool, arguments, selection)
+			if err != nil {
+				output.Error(fmt.Sprintf("failed to build call: %v", err), plaintext, jsonOut)
+				os.Exit(1)
+			}
+
+			authHeader, err := auth.GetAuthHeader()
+			if err != nil {
+				output.Error("Not authenticated. Run 'linctl auth' first.", plaintext, jsonOut)
+				os.Exit(1)
+			}
+			client := api.NewClient(authHeader)
+
+			resp, err := client.ExecuteRaw(context.Background(), query, variables)
+			if err != nil {
+				output.Error(fmt.Sprintf("MCP call failed: %v", err), plaintext, jsonOut)
+				os.Exit(1)
+			}
+
+			output.JSON(resp)
+			if len(resp.Errors) > 0 {
+				os.Exit(1)
+			}
+		},
+	}
+)
+
+var mcpInputStdin = os.Stdin
+
+func init() {
+	rootCmd.AddCommand(mcpCmd)
+
+	mcpCmd.PersistentPostRun = func(cmd *cobra.Command, args []string) {
+		_ = args
+		maybeStartAutoMCPSync(cmd)
+	}
+
+	mcpCmd.AddCommand(mcpSyncCmd)
+	mcpCmd.AddCommand(mcpToolsCmd)
+	mcpCmd.AddCommand(mcpCallCmd)
+
+	mcpSyncCmd.Flags().Bool("quiet", false, "suppress success output")
+	mcpCallCmd.Flags().String("json", "", "JSON object of tool arguments; if omitted, piped stdin is used or an empty object is sent")
+	mcpCallCmd.Flags().String("selection", "", "Override selection set (for object/interface/union returns)")
+}
+
+func runMCPSync(cmd *cobra.Command, quiet bool) error {
+	authHeader, err := auth.GetAuthHeader()
+	if err != nil {
+		return fmt.Errorf("not authenticated; run 'linctl auth' first")
+	}
+	client := api.NewClient(authHeader)
+
+	tools, err := client.DiscoverMCPTools(context.Background())
+	if err != nil {
+		return fmt.Errorf("discover MCP tools: %w", err)
+	}
+
+	cache := mcpcache.Cache{
+		FetchedAt: time.Now().UTC(),
+		Tools:     tools,
+	}
+	if err := mcpcache.Save(cache); err != nil {
+		return fmt.Errorf("save MCP cache: %w", err)
+	}
+
+	if quiet {
+		return nil
+	}
+
+	cachePath, err := mcpcache.GetPath()
+	if err != nil {
+		return fmt.Errorf("resolve cache path: %w", err)
+	}
+
+	plaintext := viper.GetBool("plaintext")
+	jsonOut := viper.GetBool("json")
+	if jsonOut {
+		output.JSON(map[string]interface{}{
+			"status":       "ok",
+			"synced_tools": len(tools),
+			"fetched_at":   cache.FetchedAt,
+			"cache":        cachePath,
+		})
+		return nil
+	}
+
+	output.Success(fmt.Sprintf("Synced %d MCP tool(s)", len(tools)), plaintext, jsonOut)
+	output.Info(fmt.Sprintf("Cache: %s", cachePath), plaintext, jsonOut)
+	return nil
+}
+
+func loadMCPArguments(flagValue string) (map[string]interface{}, error) {
+	trimmed := strings.TrimSpace(flagValue)
+	if trimmed != "" {
+		return decodeMCPArguments(trimmed)
+	}
+
+	stdinPiped, err := isMCPStdinPiped()
+	if err != nil {
+		return nil, err
+	}
+	if !stdinPiped {
+		return map[string]interface{}{}, nil
+	}
+
+	data, err := io.ReadAll(mcpInputStdin)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read stdin: %w", err)
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return map[string]interface{}{}, nil
+	}
+	return decodeMCPArguments(string(data))
+}
+
+func decodeMCPArguments(raw string) (map[string]interface{}, error) {
+	var arguments map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &arguments); err != nil {
+		return nil, fmt.Errorf("tool arguments must be a JSON object: %w", err)
+	}
+	if arguments == nil {
+		return nil, fmt.Errorf("tool arguments must be a JSON object")
+	}
+	return arguments, nil
+}
+
+func isMCPStdinPiped() (bool, error) {
+	info, err := mcpInputStdin.Stat()
+	if err != nil {
+		return false, err
+	}
+	return (info.Mode() & os.ModeCharDevice) == 0, nil
+}
+
+func resolveMCPTool(tools []api.MCPTool, requested string) (api.MCPTool, error) {
+	want := strings.TrimSpace(requested)
+	if want == "" {
+		return api.MCPTool{}, fmt.Errorf("tool name is required")
+	}
+
+	for _, tool := range tools {
+		if tool.Name == want {
+			return tool, nil
+		}
+	}
+
+	var candidates []api.MCPTool
+	for _, tool := range tools {
+		if tool.SourceField == want {
+			candidates = append(candidates, tool)
+		}
+	}
+	if len(candidates) == 1 {
+		return candidates[0], nil
+	}
+	if len(candidates) > 1 {
+		fullNames := make([]string, 0, len(candidates))
+		for _, c := range candidates {
+			fullNames = append(fullNames, c.Name)
+		}
+		sort.Strings(fullNames)
+		return api.MCPTool{}, fmt.Errorf("tool %q is ambiguous; use one of: %s", want, strings.Join(fullNames, ", "))
+	}
+
+	return api.MCPTool{}, fmt.Errorf("tool %q not found in cache; run 'linctl mcp tools' to inspect available tools", want)
+}
+
+func summarizeArgs(args []api.MCPArg) string {
+	if len(args) == 0 {
+		return "-"
+	}
+	parts := make([]string, 0, len(args))
+	for _, arg := range args {
+		marker := ""
+		if arg.Required {
+			marker = "*"
+		}
+		parts = append(parts, arg.Name+marker)
+	}
+	return strings.Join(parts, ",")
+}
+
+func summarizeDescription(s string) string {
+	text := strings.Join(strings.Fields(strings.TrimSpace(s)), " ")
+	if text == "" {
+		return "-"
+	}
+	const maxLen = 88
+	if len(text) <= maxLen {
+		return text
+	}
+	return text[:maxLen-3] + "..."
+}

--- a/cmd/mcp_autosync.go
+++ b/cmd/mcp_autosync.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/dorkitude/linctl/pkg/auth"
+	"github.com/dorkitude/linctl/pkg/mcpcache"
+	"github.com/spf13/cobra"
+)
+
+const autoMCPSyncSkipEnv = "LINCTL_SKIP_AUTO_MCP_SYNC"
+
+func maybeStartAutoMCPSync(cmd *cobra.Command) {
+	if cmd == nil {
+		return
+	}
+	if strings.TrimSpace(os.Getenv(autoMCPSyncSkipEnv)) == "1" {
+		return
+	}
+	if cmd.Name() == "sync" {
+		return
+	}
+	if _, err := auth.GetAuthHeader(); err != nil {
+		return
+	}
+
+	cache, err := mcpcache.Load()
+	if err == nil && !mcpcache.IsStale(cache, mcpCacheMaxAge) {
+		return
+	}
+
+	exePath, err := os.Executable()
+	if err != nil {
+		return
+	}
+
+	bg := exec.Command(exePath, "mcp", "sync", "--quiet")
+	bg.Env = append(os.Environ(), autoMCPSyncSkipEnv+"=1")
+	bg.Stdout = io.Discard
+	bg.Stderr = io.Discard
+	bg.Stdin = nil
+	_ = bg.Start()
+}

--- a/cmd/mcp_cmd_test.go
+++ b/cmd/mcp_cmd_test.go
@@ -1,0 +1,185 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dorkitude/linctl/pkg/api"
+	"github.com/dorkitude/linctl/pkg/mcpcache"
+	"github.com/spf13/viper"
+)
+
+func resetMCPCacheFlags(t *testing.T) {
+	t.Helper()
+	mcpInputStdin = os.Stdin
+	for _, name := range []string{"json", "selection"} {
+		flag := mcpCallCmd.Flags().Lookup(name)
+		if flag == nil {
+			t.Fatalf("missing flag %q", name)
+		}
+		if err := flag.Value.Set(flag.DefValue); err != nil {
+			t.Fatalf("reset flag %q: %v", name, err)
+		}
+		flag.Changed = false
+	}
+	quietFlag := mcpSyncCmd.Flags().Lookup("quiet")
+	if quietFlag == nil {
+		t.Fatal("missing quiet flag")
+	}
+	if err := quietFlag.Value.Set(quietFlag.DefValue); err != nil {
+		t.Fatalf("reset quiet flag: %v", err)
+	}
+	quietFlag.Changed = false
+}
+
+func TestResolveMCPTool(t *testing.T) {
+	tools := []api.MCPTool{
+		{Name: "query.viewer", SourceField: "viewer", Kind: "query"},
+		{Name: "mutation.viewer", SourceField: "viewer", Kind: "mutation"},
+		{Name: "mutation.issueCreate", SourceField: "issueCreate", Kind: "mutation"},
+	}
+
+	tool, err := resolveMCPTool(tools, "mutation.issueCreate")
+	if err != nil {
+		t.Fatalf("resolveMCPTool exact match returned error: %v", err)
+	}
+	if tool.Name != "mutation.issueCreate" {
+		t.Fatalf("expected mutation.issueCreate, got %s", tool.Name)
+	}
+
+	tool, err = resolveMCPTool(tools, "issueCreate")
+	if err != nil {
+		t.Fatalf("resolveMCPTool source field match returned error: %v", err)
+	}
+	if tool.Name != "mutation.issueCreate" {
+		t.Fatalf("expected mutation.issueCreate by source field, got %s", tool.Name)
+	}
+
+	_, err = resolveMCPTool(tools, "viewer")
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("expected ambiguous error, got %v", err)
+	}
+}
+
+func TestLoadMCPArguments(t *testing.T) {
+	resetMCPCacheFlags(t)
+
+	args, err := loadMCPArguments(`{"input":{"title":"T"}}`)
+	if err != nil {
+		t.Fatalf("loadMCPArguments with flag returned error: %v", err)
+	}
+	if _, ok := args["input"]; !ok {
+		t.Fatalf("expected input key, got %#v", args)
+	}
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer reader.Close()
+	_, _ = writer.WriteString(`{"team":"ENG"}`)
+	_ = writer.Close()
+	mcpInputStdin = reader
+
+	args, err = loadMCPArguments("")
+	if err != nil {
+		t.Fatalf("loadMCPArguments from stdin returned error: %v", err)
+	}
+	if args["team"] != "ENG" {
+		t.Fatalf("expected team ENG, got %#v", args["team"])
+	}
+}
+
+func TestRunMCPSyncWritesCache(t *testing.T) {
+	resetMCPCacheFlags(t)
+	origTransport := http.DefaultTransport
+	defer func() { http.DefaultTransport = origTransport }()
+	viper.Set("plaintext", true)
+	viper.Set("json", false)
+	t.Setenv("LINCTL_API_KEY", "test-key")
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq gqlCommandTestRequest
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("decode GraphQL request: %v", err)
+		}
+		if !strings.Contains(gqlReq.Query, "LinctlMCPIntrospection") {
+			t.Fatalf("unexpected query: %s", gqlReq.Query)
+		}
+		body := `{"data":{"__schema":{"queryType":{"name":"Query"},"mutationType":{"name":"Mutation"},"types":[{"kind":"OBJECT","name":"Query","fields":[{"name":"viewer","description":"","args":[],"type":{"kind":"OBJECT","name":"User","ofType":null}}],"inputFields":null},{"kind":"OBJECT","name":"Mutation","fields":[],"inputFields":null},{"kind":"OBJECT","name":"User","fields":[{"name":"id","description":"","args":[],"type":{"kind":"SCALAR","name":"String","ofType":null}}],"inputFields":null},{"kind":"SCALAR","name":"String","fields":null,"inputFields":null}]}}}`
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body))}, nil
+	})
+
+	if err := runMCPSync(mcpSyncCmd, false); err != nil {
+		t.Fatalf("runMCPSync returned error: %v", err)
+	}
+
+	cachePath := filepath.Join(home, ".linctl", "mcp-tools-cache.json")
+	if _, err := os.Stat(cachePath); err != nil {
+		t.Fatalf("expected cache file at %s: %v", cachePath, err)
+	}
+
+	cache, err := mcpcache.Load()
+	if err != nil {
+		t.Fatalf("mcpcache.Load returned error: %v", err)
+	}
+	if len(cache.Tools) != 1 || cache.Tools[0].Name != "query.viewer" {
+		t.Fatalf("unexpected cache tools: %#v", cache.Tools)
+	}
+}
+
+func TestMCPCmdCallExecutes(t *testing.T) {
+	resetMCPCacheFlags(t)
+	origTransport := http.DefaultTransport
+	defer func() { http.DefaultTransport = origTransport }()
+	viper.Set("plaintext", true)
+	viper.Set("json", false)
+	t.Setenv("LINCTL_API_KEY", "test-key")
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	err := mcpcache.Save(mcpcache.Cache{
+		FetchedAt: time.Now().UTC(),
+		Tools: []api.MCPTool{
+			{
+				Name:             "query.viewer",
+				Kind:             "query",
+				SourceField:      "viewer",
+				ReturnType:       "User",
+				ReturnNamedKind:  "OBJECT",
+				DefaultSelection: "{ __typename id }",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("mcpcache.Save returned error: %v", err)
+	}
+
+	var sawQuery string
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq gqlCommandTestRequest
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("decode GraphQL request: %v", err)
+		}
+		sawQuery = gqlReq.Query
+		body := `{"data":{"viewer":{"__typename":"User","id":"u1"}}}`
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body))}, nil
+	})
+
+	_ = mcpCallCmd.Flags().Set("json", `{}`)
+	mcpCallCmd.Run(mcpCallCmd, []string{"query.viewer"})
+
+	if !strings.Contains(sawQuery, "query LinctlMCPCall") || !strings.Contains(sawQuery, "viewer") {
+		t.Fatalf("unexpected query: %s", sawQuery)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,7 @@ var (
 
 // version is set at build time via -ldflags
 // default value is for local dev builds
-var version = "0.1.9-dev"
+var version = "0.1.10-dev"
 
 // generateHeader creates a nice header box with proper Unicode box drawing
 func generateHeader() string {

--- a/pkg/api/mcp.go
+++ b/pkg/api/mcp.go
@@ -1,0 +1,412 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const mcpIntrospectionQuery = `query LinctlMCPIntrospection {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    types {
+      kind
+      name
+      description
+      fields(includeDeprecated: true) {
+        name
+        description
+        args {
+          name
+          description
+          type { ...TypeRef }
+          defaultValue
+        }
+        type { ...TypeRef }
+      }
+      inputFields {
+        name
+        description
+        type { ...TypeRef }
+        defaultValue
+      }
+    }
+  }
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+type MCPTool struct {
+	Name             string   `json:"name"`
+	Kind             string   `json:"kind"`
+	SourceField      string   `json:"sourceField"`
+	Description      string   `json:"description,omitempty"`
+	Args             []MCPArg `json:"args,omitempty"`
+	ReturnType       string   `json:"returnType"`
+	ReturnNamedType  string   `json:"returnNamedType"`
+	ReturnNamedKind  string   `json:"returnNamedKind"`
+	DefaultSelection string   `json:"defaultSelection,omitempty"`
+}
+
+type MCPArg struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Type        string `json:"type"`
+	Required    bool   `json:"required"`
+}
+
+type introspectionResponse struct {
+	Schema struct {
+		QueryType struct {
+			Name string `json:"name"`
+		} `json:"queryType"`
+		MutationType *struct {
+			Name string `json:"name"`
+		} `json:"mutationType"`
+		Types []introspectionType `json:"types"`
+	} `json:"__schema"`
+}
+
+type introspectionType struct {
+	Kind        string               `json:"kind"`
+	Name        string               `json:"name"`
+	Description string               `json:"description"`
+	Fields      []introspectionField `json:"fields"`
+	InputFields []introspectionInput `json:"inputFields"`
+}
+
+type introspectionField struct {
+	Name        string             `json:"name"`
+	Description string             `json:"description"`
+	Args        []introspectionArg `json:"args"`
+	Type        *introspectionRef  `json:"type"`
+}
+
+type introspectionInput struct {
+	Name         string            `json:"name"`
+	Description  string            `json:"description"`
+	Type         *introspectionRef `json:"type"`
+	DefaultValue *string           `json:"defaultValue"`
+}
+
+type introspectionArg struct {
+	Name         string            `json:"name"`
+	Description  string            `json:"description"`
+	Type         *introspectionRef `json:"type"`
+	DefaultValue *string           `json:"defaultValue"`
+}
+
+type introspectionRef struct {
+	Kind   string            `json:"kind"`
+	Name   string            `json:"name"`
+	OfType *introspectionRef `json:"ofType"`
+}
+
+func (c *Client) DiscoverMCPTools(ctx context.Context) ([]MCPTool, error) {
+	var payload introspectionResponse
+	if err := c.Execute(ctx, mcpIntrospectionQuery, nil, &payload); err != nil {
+		return nil, err
+	}
+
+	typesByName := make(map[string]introspectionType, len(payload.Schema.Types))
+	for _, t := range payload.Schema.Types {
+		if strings.TrimSpace(t.Name) == "" {
+			continue
+		}
+		typesByName[t.Name] = t
+	}
+
+	var tools []MCPTool
+	if qt := strings.TrimSpace(payload.Schema.QueryType.Name); qt != "" {
+		tools = append(tools, buildToolsForRootType("query", qt, typesByName)...)
+	}
+	if payload.Schema.MutationType != nil {
+		if mt := strings.TrimSpace(payload.Schema.MutationType.Name); mt != "" {
+			tools = append(tools, buildToolsForRootType("mutation", mt, typesByName)...)
+		}
+	}
+
+	sort.Slice(tools, func(i, j int) bool {
+		if tools[i].Kind != tools[j].Kind {
+			return tools[i].Kind < tools[j].Kind
+		}
+		return tools[i].Name < tools[j].Name
+	})
+	return tools, nil
+}
+
+func BuildMCPCall(tool MCPTool, arguments map[string]interface{}, customSelection string) (string, map[string]interface{}, error) {
+	if arguments == nil {
+		arguments = map[string]interface{}{}
+	}
+
+	allowed := map[string]MCPArg{}
+	for _, arg := range tool.Args {
+		allowed[arg.Name] = arg
+		if arg.Required {
+			if _, ok := arguments[arg.Name]; !ok {
+				return "", nil, fmt.Errorf("missing required argument %q", arg.Name)
+			}
+		}
+	}
+	for key := range arguments {
+		if _, ok := allowed[key]; !ok {
+			return "", nil, fmt.Errorf("unknown argument %q", key)
+		}
+	}
+
+	varDefs := make([]string, 0, len(tool.Args))
+	callArgs := make([]string, 0, len(tool.Args))
+	vars := make(map[string]interface{}, len(arguments))
+	for _, arg := range tool.Args {
+		if value, ok := arguments[arg.Name]; ok {
+			varDefs = append(varDefs, fmt.Sprintf("$%s: %s", arg.Name, arg.Type))
+			callArgs = append(callArgs, fmt.Sprintf("%s: $%s", arg.Name, arg.Name))
+			vars[arg.Name] = value
+		}
+	}
+
+	selection := strings.TrimSpace(customSelection)
+	if selection == "" {
+		selection = strings.TrimSpace(tool.DefaultSelection)
+	}
+	needsSelection := tool.ReturnNamedKind == "OBJECT" || tool.ReturnNamedKind == "INTERFACE" || tool.ReturnNamedKind == "UNION"
+	if needsSelection {
+		if selection == "" {
+			selection = "{ __typename }"
+		} else {
+			selection = normalizeSelection(selection)
+		}
+	} else if selection != "" {
+		return "", nil, fmt.Errorf("tool %q returns %s and does not accept a selection set", tool.Name, tool.ReturnNamedKind)
+	}
+
+	opKeyword := strings.TrimSpace(tool.Kind)
+	if opKeyword == "" {
+		opKeyword = "query"
+	}
+
+	rootField := strings.TrimSpace(tool.SourceField)
+	if rootField == "" {
+		rootField = strings.TrimPrefix(tool.Name, opKeyword+".")
+	}
+
+	var sb strings.Builder
+	sb.WriteString(opKeyword)
+	sb.WriteString(" LinctlMCPCall")
+	if len(varDefs) > 0 {
+		sb.WriteString("(")
+		sb.WriteString(strings.Join(varDefs, ", "))
+		sb.WriteString(")")
+	}
+	sb.WriteString(" { ")
+	sb.WriteString(rootField)
+	if len(callArgs) > 0 {
+		sb.WriteString("(")
+		sb.WriteString(strings.Join(callArgs, ", "))
+		sb.WriteString(")")
+	}
+	if selection != "" {
+		sb.WriteString(" ")
+		sb.WriteString(selection)
+	}
+	sb.WriteString(" }")
+
+	return sb.String(), vars, nil
+}
+
+func buildToolsForRootType(kind, rootTypeName string, typesByName map[string]introspectionType) []MCPTool {
+	rootType, ok := typesByName[rootTypeName]
+	if !ok {
+		return nil
+	}
+
+	tools := make([]MCPTool, 0, len(rootType.Fields))
+	for _, field := range rootType.Fields {
+		fieldName := strings.TrimSpace(field.Name)
+		if fieldName == "" || strings.HasPrefix(fieldName, "__") {
+			continue
+		}
+
+		args := make([]MCPArg, 0, len(field.Args))
+		for _, arg := range field.Args {
+			typeName := formatTypeRef(arg.Type)
+			if typeName == "" {
+				continue
+			}
+			args = append(args, MCPArg{
+				Name:        arg.Name,
+				Description: strings.TrimSpace(arg.Description),
+				Type:        typeName,
+				Required:    isNonNull(arg.Type),
+			})
+		}
+
+		namedKind, namedType := unwrapNamedType(field.Type)
+		tools = append(tools, MCPTool{
+			Name:             kind + "." + fieldName,
+			Kind:             kind,
+			SourceField:      fieldName,
+			Description:      strings.TrimSpace(field.Description),
+			Args:             args,
+			ReturnType:       formatTypeRef(field.Type),
+			ReturnNamedType:  namedType,
+			ReturnNamedKind:  namedKind,
+			DefaultSelection: buildDefaultSelection(field.Type, typesByName, 1),
+		})
+	}
+
+	return tools
+}
+
+func normalizeSelection(selection string) string {
+	trimmed := strings.TrimSpace(selection)
+	if strings.HasPrefix(trimmed, "{") {
+		return trimmed
+	}
+	return "{ " + trimmed + " }"
+}
+
+func buildDefaultSelection(ref *introspectionRef, typesByName map[string]introspectionType, depth int) string {
+	kind, name := unwrapNamedType(ref)
+	switch kind {
+	case "SCALAR", "ENUM":
+		return ""
+	case "UNION":
+		return "{ __typename }"
+	case "OBJECT", "INTERFACE":
+		if strings.TrimSpace(name) == "" {
+			return "{ __typename }"
+		}
+		selection := buildSelectionForNamedType(name, typesByName, depth, map[string]bool{})
+		if selection == "" {
+			return "{ __typename }"
+		}
+		return selection
+	default:
+		return ""
+	}
+}
+
+func buildSelectionForNamedType(typeName string, typesByName map[string]introspectionType, depth int, stack map[string]bool) string {
+	if stack[typeName] {
+		return "{ __typename }"
+	}
+	t, ok := typesByName[typeName]
+	if !ok {
+		return "{ __typename }"
+	}
+	if t.Kind == "UNION" {
+		return "{ __typename }"
+	}
+	if t.Kind != "OBJECT" && t.Kind != "INTERFACE" {
+		return ""
+	}
+
+	stack[typeName] = true
+	defer delete(stack, typeName)
+
+	parts := []string{"__typename"}
+	added := 0
+	for _, field := range t.Fields {
+		if strings.HasPrefix(field.Name, "__") || strings.TrimSpace(field.Name) == "" {
+			continue
+		}
+		if hasRequiredArguments(field.Args) {
+			continue
+		}
+		fieldKind, _ := unwrapNamedType(field.Type)
+		switch fieldKind {
+		case "SCALAR", "ENUM":
+			parts = append(parts, field.Name)
+			added++
+		case "OBJECT", "INTERFACE", "UNION":
+			if depth > 0 {
+				parts = append(parts, field.Name+" { __typename }")
+				added++
+			}
+		}
+		if added >= 24 {
+			break
+		}
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+	return "{ " + strings.Join(parts, " ") + " }"
+}
+
+func hasRequiredArguments(args []introspectionArg) bool {
+	for _, arg := range args {
+		if isNonNull(arg.Type) && arg.DefaultValue == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func isNonNull(ref *introspectionRef) bool {
+	return ref != nil && ref.Kind == "NON_NULL"
+}
+
+func unwrapNamedType(ref *introspectionRef) (string, string) {
+	for ref != nil {
+		if strings.TrimSpace(ref.Name) != "" {
+			return ref.Kind, ref.Name
+		}
+		ref = ref.OfType
+	}
+	return "", ""
+}
+
+func formatTypeRef(ref *introspectionRef) string {
+	if ref == nil {
+		return ""
+	}
+	switch ref.Kind {
+	case "NON_NULL":
+		inner := formatTypeRef(ref.OfType)
+		if inner == "" {
+			return ""
+		}
+		return inner + "!"
+	case "LIST":
+		inner := formatTypeRef(ref.OfType)
+		if inner == "" {
+			return ""
+		}
+		return "[" + inner + "]"
+	default:
+		return strings.TrimSpace(ref.Name)
+	}
+}

--- a/pkg/api/mcp_test.go
+++ b/pkg/api/mcp_test.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type gqlMCPTestRequest struct {
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables"`
+}
+
+func TestDiscoverMCPTools(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req gqlMCPTestRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if !strings.Contains(req.Query, "LinctlMCPIntrospection") {
+			t.Fatalf("expected introspection query, got: %s", req.Query)
+		}
+
+		body := `{"data":{"__schema":{"queryType":{"name":"Query"},"mutationType":{"name":"Mutation"},"types":[{"kind":"OBJECT","name":"Query","description":"","fields":[{"name":"viewer","description":"Current viewer","args":[],"type":{"kind":"OBJECT","name":"User","ofType":null}},{"name":"issue","description":"Get issue","args":[{"name":"id","description":"Issue ID","type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}},"defaultValue":null}],"type":{"kind":"OBJECT","name":"Issue","ofType":null}}],"inputFields":null},{"kind":"OBJECT","name":"Mutation","description":"","fields":[{"name":"issueCreate","description":"Create issue","args":[{"name":"input","description":"Create payload","type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"INPUT_OBJECT","name":"IssueCreateInput","ofType":null}},"defaultValue":null}],"type":{"kind":"OBJECT","name":"IssuePayload","ofType":null}}],"inputFields":null},{"kind":"OBJECT","name":"User","description":"","fields":[{"name":"id","description":"","args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}}},{"name":"name","description":"","args":[],"type":{"kind":"SCALAR","name":"String","ofType":null}},{"name":"organization","description":"","args":[],"type":{"kind":"OBJECT","name":"Organization","ofType":null}}],"inputFields":null},{"kind":"OBJECT","name":"Issue","description":"","fields":[{"name":"id","description":"","args":[],"type":{"kind":"SCALAR","name":"String","ofType":null}},{"name":"title","description":"","args":[],"type":{"kind":"SCALAR","name":"String","ofType":null}}],"inputFields":null},{"kind":"OBJECT","name":"IssuePayload","description":"","fields":[{"name":"success","description":"","args":[],"type":{"kind":"SCALAR","name":"Boolean","ofType":null}},{"name":"issue","description":"","args":[],"type":{"kind":"OBJECT","name":"Issue","ofType":null}}],"inputFields":null},{"kind":"OBJECT","name":"Organization","description":"","fields":[{"name":"id","description":"","args":[],"type":{"kind":"SCALAR","name":"String","ofType":null}}],"inputFields":null},{"kind":"INPUT_OBJECT","name":"IssueCreateInput","description":"","fields":null,"inputFields":[{"name":"title","description":"","type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}},"defaultValue":null}]},{"kind":"SCALAR","name":"String","description":"","fields":null,"inputFields":null},{"kind":"SCALAR","name":"Boolean","description":"","fields":null,"inputFields":null}]}}}`
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithURL(srv.URL, "Bearer test")
+	tools, err := c.DiscoverMCPTools(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverMCPTools returned error: %v", err)
+	}
+	if len(tools) != 3 {
+		t.Fatalf("expected 3 tools, got %d", len(tools))
+	}
+
+	var sawQueryViewer bool
+	var sawMutationCreate bool
+	for _, tool := range tools {
+		switch tool.Name {
+		case "query.viewer":
+			sawQueryViewer = true
+			if tool.ReturnNamedKind != "OBJECT" {
+				t.Fatalf("expected query.viewer object return, got %s", tool.ReturnNamedKind)
+			}
+			if !strings.Contains(tool.DefaultSelection, "__typename") {
+				t.Fatalf("expected default selection for query.viewer, got %q", tool.DefaultSelection)
+			}
+		case "mutation.issueCreate":
+			sawMutationCreate = true
+			if len(tool.Args) != 1 || tool.Args[0].Name != "input" || !tool.Args[0].Required {
+				t.Fatalf("unexpected mutation args: %#v", tool.Args)
+			}
+		}
+	}
+	if !sawQueryViewer {
+		t.Fatal("missing query.viewer tool")
+	}
+	if !sawMutationCreate {
+		t.Fatal("missing mutation.issueCreate tool")
+	}
+}
+
+func TestBuildMCPCall(t *testing.T) {
+	tool := MCPTool{
+		Name:             "mutation.issueCreate",
+		Kind:             "mutation",
+		SourceField:      "issueCreate",
+		ReturnNamedKind:  "OBJECT",
+		DefaultSelection: "{ __typename success }",
+		Args: []MCPArg{
+			{Name: "input", Type: "IssueCreateInput!", Required: true},
+			{Name: "clientMutationId", Type: "String", Required: false},
+		},
+	}
+
+	query, vars, err := BuildMCPCall(tool, map[string]interface{}{
+		"input": map[string]interface{}{"title": "Test"},
+	}, "")
+	if err != nil {
+		t.Fatalf("BuildMCPCall returned error: %v", err)
+	}
+	if !strings.Contains(query, "mutation LinctlMCPCall") || !strings.Contains(query, "issueCreate(input: $input)") {
+		t.Fatalf("unexpected query: %s", query)
+	}
+	if !strings.Contains(query, "{ __typename success }") {
+		t.Fatalf("expected default selection in query, got: %s", query)
+	}
+	if _, ok := vars["input"]; !ok {
+		t.Fatalf("expected input variable, got %#v", vars)
+	}
+
+	_, _, err = BuildMCPCall(tool, map[string]interface{}{}, "")
+	if err == nil || !strings.Contains(err.Error(), "missing required") {
+		t.Fatalf("expected missing required argument error, got: %v", err)
+	}
+
+	_, _, err = BuildMCPCall(tool, map[string]interface{}{"input": map[string]interface{}{}, "extra": true}, "")
+	if err == nil || !strings.Contains(err.Error(), "unknown argument") {
+		t.Fatalf("expected unknown argument error, got: %v", err)
+	}
+}
+
+func TestBuildMCPCallRejectsSelectionForScalar(t *testing.T) {
+	tool := MCPTool{
+		Name:            "query.viewerCount",
+		Kind:            "query",
+		SourceField:     "viewerCount",
+		ReturnNamedKind: "SCALAR",
+	}
+
+	_, _, err := BuildMCPCall(tool, nil, "{ value }")
+	if err == nil || !strings.Contains(err.Error(), "does not accept a selection set") {
+		t.Fatalf("expected scalar selection error, got: %v", err)
+	}
+}

--- a/pkg/mcpcache/cache.go
+++ b/pkg/mcpcache/cache.go
@@ -1,0 +1,109 @@
+package mcpcache
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/dorkitude/linctl/pkg/api"
+)
+
+const (
+	cacheDirName  = ".linctl"
+	cacheFileName = "mcp-tools-cache.json"
+)
+
+type Cache struct {
+	FetchedAt time.Time     `json:"fetched_at"`
+	Tools     []api.MCPTool `json:"tools"`
+}
+
+func GetPath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, cacheDirName, cacheFileName), nil
+}
+
+func Load() (*Cache, error) {
+	path, err := GetPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errors.New("mcp cache not found")
+		}
+		return nil, err
+	}
+
+	var cache Cache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return nil, err
+	}
+	if cache.Tools == nil {
+		cache.Tools = []api.MCPTool{}
+	}
+	return &cache, nil
+}
+
+func Save(cache Cache) error {
+	path, err := GetPath()
+	if err != nil {
+		return err
+	}
+	if cache.FetchedAt.IsZero() {
+		cache.FetchedAt = time.Now().UTC()
+	}
+	if cache.Tools == nil {
+		cache.Tools = []api.MCPTool{}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmpFile, err := os.CreateTemp(filepath.Dir(path), strings.TrimSpace(cacheFileName)+".tmp.*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := tmpFile.Chmod(0600); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+func IsStale(cache *Cache, maxAge time.Duration) bool {
+	if cache == nil {
+		return true
+	}
+	if cache.FetchedAt.IsZero() {
+		return true
+	}
+	return time.Since(cache.FetchedAt) > maxAge
+}


### PR DESCRIPTION
Closes #49

## Summary
- add `linctl mcp` namespace with dynamic operations discovered from live GraphQL introspection
- add local cache (`~/.linctl/mcp-tools-cache.json`) with 12-hour staleness semantics
- add `linctl mcp sync`, `linctl mcp tools`, and `linctl mcp call <tool>`
- add background auto-sync for stale/missing cache with recursion guard env var
- add command tests (`cmd/mcp_cmd_test.go`) and API tests (`pkg/api/mcp_test.go`)
- document new commands in `README.md` and `SKILL.md`

## Notes
- dynamic tool names use `query.<field>` / `mutation.<field>` prefixes
- `linctl mcp call` also accepts unprefixed field names when unambiguous
- for object/interface/union returns, `--selection` can override the default generated selection set

## Validation
- `go test ./...`
- `go run . --version`
- `go run . --help`
- `go run . mcp --help`