### PR TITLE
feat(initiative): add initiative CRUD commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # linctl
 
-
 A command-line interface for the Linear API, built with Go and Cobra.
 
 ## Features
@@ -11,6 +10,7 @@ A command-line interface for the Linear API, built with Go and Cobra.
   - due dates, attachments, comments, and rich issue detail output
   - issue relations (blocks, blocked-by, related, duplicate, similar)
 - **Projects**: list/get/create/update/delete/archive.
+- **Initiatives**: list/get/create/update/delete/archive/unarchive/link/unlink.
 - **Teams**: list/get/members/state (list/update).
 - **Users**: list/get/me.
 - **Labels**: list/get/create/update/delete.
@@ -26,6 +26,7 @@ A command-line interface for the Linear API, built with Go and Cobra.
 ## Installation
 
 ### Homebrew (macOS/Linux)
+
 ```bash
 brew tap dorkitude/linctl
 brew install linctl
@@ -33,12 +34,14 @@ linctl docs      # Render the README.md
 ```
 
 ### Nix
+
 ```bash
 nix profile install github:dorkitude/linctl
 linctl docs      # Render the README.md
 ```
 
 ### From Source
+
 ```bash
 git clone https://github.com/dorkitude/linctl.git
 cd linctl
@@ -49,6 +52,7 @@ linctl docs      # Render the README.md
 ```
 
 ### For Development
+
 ```bash
 git clone https://github.com/dorkitude/linctl.git
 cd linctl
@@ -64,21 +68,23 @@ linctl docs      # Render the README.md
 ## Important: Default Filters
 
 **By default, `issue list`, `issue search`, and `project list` commands only show items created in the last 6 months!**
- 
+
 This improves performance and prevents overwhelming data loads. To see older items:
- - Use `--newer-than 1_year_ago` for items from the last year
- - Use `--newer-than all_time` to see ALL items ever created
- - See the [Time-based Filtering](#-time-based-filtering) section for details
+
+- Use `--newer-than 1_year_ago` for items from the last year
+- Use `--newer-than all_time` to see ALL items ever created
+- See the [Time-based Filtering](#-time-based-filtering) section for details
 
 **By default, `issue list` and `issue search` also filter out canceled and completed items. To see all items, use the `--include-completed` flag.**
-- Need archived matches? Add `--include-archived` when using `issue search`.
 
+- Need archived matches? Add `--include-archived` when using `issue search`.
 
 ## Quick Start
 
-> **IMPORTANT**  Agents like Claude Code, Cursor, and Gemini should use the `--json` flag on all read operations.
+> **IMPORTANT** Agents like Claude Code, Cursor, and Gemini should use the `--json` flag on all read operations.
 
 ### 1. Authentication
+
 ```bash
 # Interactive authentication
 linctl auth
@@ -94,6 +100,7 @@ linctl docs | less
 ```
 
 ### 2. Issue Management
+
 ```bash
 # List all issues
 linctl issue list
@@ -193,6 +200,7 @@ linctl issue relation remove RELATION-ID        # Use ID from relation list
 ```
 
 ### 3. Project Management
+
 ```bash
 # List all projects (shows IDs)
 linctl project list
@@ -220,7 +228,41 @@ linctl project delete PROJECT-ID
 linctl project delete PROJECT-ID --permanent --force
 ```
 
-### 4. Team Management
+### 4. Initiative Management
+
+```bash
+# List all active initiatives
+linctl initiative list
+
+# List all initiatives including completed
+linctl initiative list --include-completed
+
+# Filter by status
+linctl initiative list --status active
+
+# Get initiative details
+linctl initiative get INITIATIVE-ID
+
+# Create an initiative
+linctl initiative create --name "Q3 Revenue Goals" --owner me --status Active
+
+# Update an initiative
+linctl initiative update INITIATIVE-ID --target-date 2026-12-31
+
+# Archive / unarchive
+linctl initiative archive INITIATIVE-ID
+linctl initiative unarchive INITIATIVE-ID
+
+# Permanently delete
+linctl initiative delete INITIATIVE-ID --force
+
+# Link / unlink a project
+linctl initiative link INITIATIVE-ID --project PROJECT-ID
+linctl initiative unlink INITIATIVE-ID --project PROJECT-ID
+```
+
+### 5. Team Management
+
 ```bash
 # List all teams
 linctl team list
@@ -238,7 +280,8 @@ linctl team state list ENG
 linctl team state update STATE-ID --name "Ready" --color "#abc"
 ```
 
-### 5. User Management
+### 6. User Management
+
 ```bash
 # List all users
 linctl user list
@@ -253,7 +296,8 @@ linctl user get john@example.com
 linctl user me
 ```
 
-### 6. Comments
+### 7. Comments
+
 ```bash
 # List comments on an issue
 linctl comment list LIN-123
@@ -267,7 +311,8 @@ linctl comment update COMMENT-ID --body "Updated comment body"
 linctl comment delete COMMENT-ID
 ```
 
-### 7. Label Management
+### 8. Label Management
+
 ```bash
 # List labels for a team
 linctl label list --team ENG
@@ -286,7 +331,8 @@ linctl label update LABEL-ID --name "critical bug"
 linctl label delete LABEL-ID
 ```
 
-### 8. Agent Sessions
+### 9. Agent Sessions
+
 ```bash
 # View delegated/agent session state for an issue
 linctl agent ENG-80
@@ -298,7 +344,8 @@ linctl agent mention ENG-80 "Please investigate this failure"
 linctl agent mention ENG-80 --agent agent-runner "Please rerun tests"
 ```
 
-### 9. Raw GraphQL (API Escape Hatch)
+### 10. Raw GraphQL (API Escape Hatch)
+
 ```bash
 # Direct query
 linctl graphql 'query { viewer { id name email } }'
@@ -316,7 +363,8 @@ linctl graphql --file query.graphql --variables-file vars.json
 cat query.graphql | linctl graphql --variables '{"k":"ENG"}'
 ```
 
-### 10. Dynamic MCP Tools (Schema-Driven)
+### 11. Dynamic MCP Tools (Schema-Driven)
+
 ```bash
 # Sync cache from live schema introspection (12h TTL)
 linctl mcp sync
@@ -337,12 +385,14 @@ linctl mcp call query.issue --json '{"id":"LIN-123"}' --selection '{ id identifi
 ## Command Reference
 
 ### Global Flags
+
 - `--plaintext, -p`: Plain text output (non-interactive)
 - `--json, -j`: JSON output for scripting
 - `--help, -h`: Show help
 - `--version, -v`: Show version
 
 ### Authentication Commands
+
 ```bash
 linctl auth               # Interactive authentication
 linctl auth login         # Same as above
@@ -352,6 +402,7 @@ linctl whoami            # Show current user
 ```
 
 ### GraphQL Command
+
 ```bash
 # Execute raw GraphQL operation
 linctl graphql [query] [flags]
@@ -364,6 +415,7 @@ linctl graphql [query] [flags]
 ```
 
 ### MCP Commands
+
 ```bash
 # Refresh cache of dynamic tools discovered from Linear schema
 linctl mcp sync
@@ -380,6 +432,7 @@ linctl mcp call <tool-name> [flags]
 ```
 
 ### Issue Commands
+
 ```bash
 # List issues with filters
 linctl issue list [flags]
@@ -463,6 +516,7 @@ linctl issue attachment download <issue-id> [flags]
 ```
 
 ### Issue Relation Commands
+
 ```bash
 # List all relations for an issue
 linctl issue relation list <issue-id>
@@ -490,6 +544,7 @@ linctl issue relation list LIN-123 -j                    # JSON output for scrip
 ```
 
 ### Agent Commands
+
 ```bash
 # View agent delegation/session for an issue
 linctl agent <issue-id>
@@ -501,6 +556,7 @@ linctl agent mention <issue-id> <message...>
 ```
 
 ### Team Commands
+
 ```bash
 # List all teams with issue counts
 linctl team list
@@ -537,6 +593,7 @@ linctl team state update abc123 --name "Ready" --color "#00ff00"
 ```
 
 ### Project Commands
+
 ```bash
 # List projects
 linctl project list [flags]
@@ -586,7 +643,60 @@ linctl project remove <project-id> [flags]
   -f, --force            Skip confirmation prompt
 ```
 
+### Initiative Commands
+
+```bash
+# List initiatives
+linctl initiative list [flags]
+linctl initiative ls [flags]      # Alias
+# Flags:
+  -s, --status string        Filter by status (Planned, Active, Completed)
+  -l, --limit int            Maximum results (default 50)
+  -c, --include-completed    Include completed initiatives
+
+# Get initiative details
+linctl initiative get <initiative-id>
+linctl initiative show <initiative-id>  # Alias
+
+# Create initiative
+linctl initiative create [flags]
+linctl initiative new [flags]     # Alias
+# Key flags:
+  --name string            Initiative name (required)
+  -d, --description        Description
+  -s, --status             Planned|Active|Completed
+  --owner                  email|name|me
+  --target-date            YYYY-MM-DD
+  --color                  Hex color
+
+# Update initiative
+linctl initiative update <initiative-id> [flags]
+# Key flags:
+  --name string
+  -d, --description
+  -s, --status             Planned|Active|Completed
+  --owner                  email|name|me|none
+  --target-date            YYYY-MM-DD or empty to clear
+  --color                  Hex color
+
+# Archive / unarchive initiative
+linctl initiative archive <initiative-id>
+linctl initiative unarchive <initiative-id>
+
+# Permanently delete initiative
+linctl initiative delete <initiative-id> [flags]
+linctl initiative rm <initiative-id> [flags]
+linctl initiative remove <initiative-id> [flags]
+# Key flags:
+  -f, --force              Skip confirmation prompt
+
+# Link / unlink initiative to project
+linctl initiative link <initiative-id> --project <project-id>
+linctl initiative unlink <initiative-id> --project <project-id>
+```
+
 ### User Commands
+
 ```bash
 # List all users in workspace
 linctl user list [flags]
@@ -613,6 +723,7 @@ linctl user me              # Shows your profile with admin status
 ```
 
 ### Comment Commands
+
 ```bash
 # List all comments for an issue
 linctl comment list <issue-id> [flags]
@@ -645,6 +756,7 @@ linctl comment create LIN-456 --body "@john please review this PR"
 ```
 
 ### Label Commands
+
 ```bash
 # List labels for a team
 linctl label list --team <team-key>
@@ -679,9 +791,11 @@ linctl label remove <label-id>         # Alias
 ## Output Formats
 
 ### Table Format (Default)
+
 ```bash
 linctl issue list
 ```
+
 ```
 ID       Title                State        Assignee    Team  Priority
 LIN-123  Fix authentication   In Progress  john@co.com ENG   High
@@ -689,9 +803,11 @@ LIN-124  Update documentation Done         jane@co.com DOC   Normal
 ```
 
 ### Plaintext Format
+
 ```bash
 linctl issue list --plaintext
 ```
+
 ```
 # Issues
 ## BUG: Fix login button alignment
@@ -719,9 +835,11 @@ Steps to reproduce:
 ```
 
 ### JSON Format
+
 ```bash
 linctl issue list --json
 ```
+
 ```json
 [
   {
@@ -759,6 +877,7 @@ can opt in to GPG-backed credential storage with `LINCTL_PASS_NAME`.
 ## Authentication
 
 ### Personal API Key (Recommended)
+
 1. Go to [Linear Settings > Security & Access](https://linear.app/<your-org>/settings/account/security)
 2. Scroll to **Personal API keys** and create a new key
 3. Run `linctl auth` and paste your key
@@ -766,6 +885,7 @@ can opt in to GPG-backed credential storage with `LINCTL_PASS_NAME`.
 ### Temporary Override (Current Session)
 
 You can temporarily override stored credentials using the `LINCTL_API_KEY` environment variable. This is useful for:
+
 - CI/CD pipelines
 - Testing with a different account
 - One-off commands without modifying `~/.linctl-auth.json`
@@ -839,18 +959,18 @@ linctl issue list --newer-than all_time
 
 ### Quick Reference
 
-| Time Expression | Description | Example Command |
-|----------------|-------------|-----------------|
-| *(no flag)* | Last 6 months (default) | `linctl issue list` |
-| `1_day_ago` | Last 24 hours | `linctl issue list --newer-than 1_day_ago` |
-| `1_week_ago` | Last 7 days | `linctl issue list --newer-than 1_week_ago` |
-| `2_weeks_ago` | Last 14 days | `linctl issue list --newer-than 2_weeks_ago` |
-| `1_month_ago` | Last month | `linctl issue list --newer-than 1_month_ago` |
-| `3_months_ago` | Last quarter | `linctl issue list --newer-than 3_months_ago` |
-| `6_months_ago` | Last 6 months | `linctl issue list --newer-than 6_months_ago` |
-| `1_year_ago` | Last year | `linctl issue list --newer-than 1_year_ago` |
-| `all_time` | No date filter | `linctl issue list --newer-than all_time` |
-| `2025-07-01` | Since specific date | `linctl issue list --newer-than 2025-07-01` |
+| Time Expression | Description             | Example Command                               |
+| --------------- | ----------------------- | --------------------------------------------- |
+| _(no flag)_     | Last 6 months (default) | `linctl issue list`                           |
+| `1_day_ago`     | Last 24 hours           | `linctl issue list --newer-than 1_day_ago`    |
+| `1_week_ago`    | Last 7 days             | `linctl issue list --newer-than 1_week_ago`   |
+| `2_weeks_ago`   | Last 14 days            | `linctl issue list --newer-than 2_weeks_ago`  |
+| `1_month_ago`   | Last month              | `linctl issue list --newer-than 1_month_ago`  |
+| `3_months_ago`  | Last quarter            | `linctl issue list --newer-than 3_months_ago` |
+| `6_months_ago`  | Last 6 months           | `linctl issue list --newer-than 6_months_ago` |
+| `1_year_ago`    | Last year               | `linctl issue list --newer-than 1_year_ago`   |
+| `all_time`      | No date filter          | `linctl issue list --newer-than all_time`     |
+| `2025-07-01`    | Since specific date     | `linctl issue list --newer-than 2025-07-01`   |
 
 ### Common Use Cases
 
@@ -883,6 +1003,7 @@ All list commands support sorting with the `--sort` or `-o` flag:
 - **updated**: Sort by last update date (most recently updated first)
 
 ### Examples
+
 ```bash
 # Get recently updated issues
 linctl issue list --sort updated
@@ -966,6 +1087,7 @@ linctl comment list LIN-123 --json > issue-comments.json
 ## Real-World Examples
 
 ### Team Workflows
+
 ```bash
 # Find which team a user belongs to
 for team in $(linctl team list --json | jq -r '.[].key'); do
@@ -981,6 +1103,7 @@ linctl team list --json | jq '.[] | select(.issueCount > 50) | {key, name, issue
 ```
 
 ### User Management
+
 ```bash
 # Find inactive users
 linctl user list --json | jq '.[] | select(.active == false) | {name, email}'
@@ -993,6 +1116,7 @@ linctl user list --json | jq '.[] | select(.admin == true and .isMe == false) | 
 ```
 
 ### Issue Comments
+
 ```bash
 # Add a comment mentioning the issue is blocked
 linctl comment create LIN-123 --body "Blocked by LIN-456. Waiting for API changes."
@@ -1008,6 +1132,7 @@ done
 ```
 
 ### Project Tracking
+
 ```bash
 # List projects nearing completion (>80% progress)
 linctl project list --json | jq '.[] | select(.progress > 0.8) | {name, progress}'
@@ -1020,6 +1145,7 @@ linctl project get PROJECT-ID --json | jq '{name, startDate, targetDate, progres
 ```
 
 ### Daily Standup Helper
+
 ```bash
 #!/bin/bash
 # Show my recent activity
@@ -1036,6 +1162,7 @@ done
 ## Troubleshooting
 
 ### Authentication Issues
+
 ```bash
 # Check authentication status
 linctl auth status
@@ -1046,15 +1173,19 @@ linctl auth
 ```
 
 ### API Rate Limits
+
 Linear has the following rate limits:
+
 - Personal API Keys: 5,000 requests/hour
 
 ### Common Errors
+
 - `Not authenticated`: Run `linctl auth` first
 - `Team not found`: Use team key (e.g., "ENG") not display name
 - `Invalid priority`: Use numbers 0-4 (0=None, 1=Urgent, 2=High, 3=Normal, 4=Low)
 
 ### Time Filtering Issues
+
 - **Missing old issues?** Remember that list commands default to showing only the last 6 months
   - Solution: Use `--newer-than all_time` to see all issues
 - **Invalid time expression?** Check the format: `N_units_ago` (e.g., `3_weeks_ago`)

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linctl
-description: Use linctl to read and update Linear issues, projects, teams, users, labels, comments, and agent sessions from the terminal. Prefer JSON reads, validate auth first, and use command-specific --help for exact flags.
+description: Use linctl to read and update Linear issues, projects, initiatives, teams, users, labels, comments, and agent sessions from the terminal. Prefer JSON reads, validate auth first, and use command-specific --help for exact flags.
 ---
 
 # linctl Agent Guide
@@ -46,6 +46,7 @@ Use this skill when the user wants to inspect or modify Linear data through `lin
 
 - Issues: `linctl issue ...`
 - Projects: `linctl project ...`
+- Initiatives: `linctl initiative ...` (list, get, create, update, delete, archive, unarchive, link, unlink)
 - Teams: `linctl team ...` (includes `state list` and `state update`)
 - Users: `linctl user ...` and `linctl whoami`
 - Comments: `linctl comment ...`
@@ -82,6 +83,11 @@ linctl agent <ISSUE_ID> --json
 linctl mcp sync
 linctl mcp tools --json
 linctl mcp call query.viewer
+
+# Initiative inventory
+linctl initiative list --json
+linctl initiative list --include-completed --json
+linctl initiative get <INITIATIVE_ID> --json
 ```
 
 ## Suggested Write Patterns
@@ -121,6 +127,14 @@ linctl team state update <STATE_ID> --name "Ready"
 
 # Mention delegated/active agent with message
 linctl agent mention LIN-123 "Please pick this up."
+
+# Initiative lifecycle
+linctl initiative create --name "Q3 Goals" --owner me --status Active
+linctl initiative update <INIT_ID> --target-date 2026-12-31
+linctl initiative link <INIT_ID> --project <PROJECT_ID>
+linctl initiative unlink <INIT_ID> --project <PROJECT_ID>
+linctl initiative archive <INIT_ID>
+linctl initiative unarchive <INIT_ID>
 ```
 
 ## Troubleshooting
@@ -146,5 +160,6 @@ linctl user --help
 linctl comment --help
 linctl label --help
 linctl agent --help
+linctl initiative --help
 linctl auth --help
 ```

--- a/cmd/initiative.go
+++ b/cmd/initiative.go
@@ -1,0 +1,898 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/dorkitude/linctl/pkg/api"
+	"github.com/dorkitude/linctl/pkg/auth"
+	"github.com/dorkitude/linctl/pkg/output"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// initiativeCmd represents the initiative command
+var initiativeCmd = &cobra.Command{
+	Use:   "initiative",
+	Short: "Manage Linear initiatives",
+	Long: `Manage Linear initiatives including listing, viewing, creating, and linking to projects.
+
+Examples:
+  linctl initiative list                        # List active initiatives
+  linctl initiative list --include-completed    # List all initiatives
+  linctl initiative get INITIATIVE-ID           # Get initiative details
+  linctl initiative create --name "Q3 Goals"    # Create a new initiative
+  linctl initiative link INIT-ID --project PROJECT-ID  # Link to project`,
+}
+
+var initiativeListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List initiatives",
+	Long:    `List all initiatives in your Linear workspace.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		plaintext := viper.GetBool("plaintext")
+		jsonOut := viper.GetBool("json")
+
+		authHeader, err := auth.GetAuthHeader()
+		if err != nil {
+			output.Error(fmt.Sprintf("Authentication failed: %v", err), plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		client := api.NewClient(authHeader)
+
+		status, _ := cmd.Flags().GetString("status")
+		limit, _ := cmd.Flags().GetInt("limit")
+		includeCompleted, _ := cmd.Flags().GetBool("include-completed")
+
+		filter := make(map[string]interface{})
+		if status != "" {
+			// Validate and normalize status
+			validStatuses := []string{"Planned", "Active", "Completed"}
+			normalized := normalizeInitiativeStatus(status)
+			if normalized == "" {
+				output.Error(fmt.Sprintf("Invalid status '%s'. Valid statuses: %s", status, strings.Join(validStatuses, ", ")), plaintext, jsonOut)
+				os.Exit(1)
+			}
+			filter["status"] = map[string]interface{}{"eq": normalized}
+		} else if !includeCompleted {
+			filter["status"] = map[string]interface{}{
+				"neq": "Completed",
+			}
+		}
+
+		initiatives, err := client.GetInitiatives(context.Background(), filter, limit, "")
+		if err != nil {
+			output.Error(fmt.Sprintf("Failed to list initiatives: %v", err), plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		if jsonOut {
+			output.JSON(initiatives.Nodes)
+			return
+		} else if plaintext {
+			fmt.Println("# Initiatives")
+			for _, init := range initiatives.Nodes {
+				fmt.Printf("## %s\n", init.Name)
+				fmt.Printf("- **ID**: %s\n", init.ID)
+				fmt.Printf("- **Status**: %s\n", init.Status)
+				if init.Owner != nil {
+					fmt.Printf("- **Owner**: %s\n", init.Owner.Name)
+				} else {
+					fmt.Printf("- **Owner**: Unassigned\n")
+				}
+				if init.TargetDate != nil {
+					fmt.Printf("- **Target Date**: %s\n", *init.TargetDate)
+				}
+				if init.Projects != nil && len(init.Projects.Nodes) > 0 {
+					projects := ""
+					for i, p := range init.Projects.Nodes {
+						if i > 0 {
+							projects += ", "
+						}
+						projects += p.Name
+					}
+					fmt.Printf("- **Projects**: %s\n", projects)
+				}
+				fmt.Printf("- **Created**: %s\n", init.CreatedAt.Format("2006-01-02"))
+				fmt.Printf("- **Updated**: %s\n", init.UpdatedAt.Format("2006-01-02"))
+				fmt.Printf("- **URL**: %s\n", init.URL)
+				if init.Description != "" {
+					fmt.Printf("- **Description**: %s\n", init.Description)
+				}
+				fmt.Println()
+			}
+			fmt.Printf("\nTotal: %d initiatives\n", len(initiatives.Nodes))
+			return
+		}
+
+		// Table output
+		headers := []string{"Name", "Status", "Owner", "Projects", "Target Date", "Created", "URL"}
+		rows := [][]string{}
+
+		for _, init := range initiatives.Nodes {
+			owner := color.New(color.FgYellow).Sprint("Unassigned")
+			if init.Owner != nil {
+				owner = init.Owner.Name
+			}
+
+			projectCount := ""
+			if init.Projects != nil {
+				projectCount = fmt.Sprintf("%d", len(init.Projects.Nodes))
+			}
+
+			targetDate := ""
+			if init.TargetDate != nil {
+				targetDate = *init.TargetDate
+			}
+
+			statusColor := initiativeStatusColor(init.Status)
+
+			rows = append(rows, []string{
+				truncateString(init.Name, 30),
+				statusColor.Sprint(init.Status),
+				owner,
+				projectCount,
+				targetDate,
+				init.CreatedAt.Format("2006-01-02"),
+				init.URL,
+			})
+		}
+
+		output.Table(output.TableData{
+			Headers: headers,
+			Rows:    rows,
+		}, plaintext, jsonOut)
+
+		fmt.Printf("\n%s %d initiatives\n",
+			color.New(color.FgGreen).Sprint("✓"),
+			len(initiatives.Nodes))
+	},
+}
+
+var initiativeGetCmd = &cobra.Command{
+	Use:     "get INITIATIVE-ID",
+	Aliases: []string{"show"},
+	Short:   "Get initiative details",
+	Long:    `Get detailed information about a specific initiative.`,
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		plaintext := viper.GetBool("plaintext")
+		jsonOut := viper.GetBool("json")
+		initiativeID := args[0]
+
+		authHeader, err := auth.GetAuthHeader()
+		if err != nil {
+			output.Error(fmt.Sprintf("Authentication failed: %v", err), plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		client := api.NewClient(authHeader)
+
+		initiative, err := client.GetInitiative(context.Background(), initiativeID)
+		if err != nil {
+			output.Error(fmt.Sprintf("Failed to get initiative: %v", err), plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		if jsonOut {
+			output.JSON(initiative)
+			return
+		} else if plaintext {
+			fmt.Printf("# %s\n\n", initiative.Name)
+
+			if initiative.Description != "" {
+				fmt.Printf("## Description\n%s\n\n", initiative.Description)
+			}
+
+			if initiative.Content != "" {
+				fmt.Printf("## Content\n%s\n\n", initiative.Content)
+			}
+
+			fmt.Printf("## Core Details\n")
+			fmt.Printf("- **ID**: %s\n", initiative.ID)
+			fmt.Printf("- **Slug ID**: %s\n", initiative.SlugId)
+			fmt.Printf("- **Status**: %s\n", initiative.Status)
+			if initiative.Icon != nil && *initiative.Icon != "" {
+				fmt.Printf("- **Icon**: %s\n", *initiative.Icon)
+			}
+			if initiative.Color != nil && *initiative.Color != "" {
+				fmt.Printf("- **Color**: %s\n", *initiative.Color)
+			}
+
+			fmt.Printf("\n## Timeline\n")
+			if initiative.TargetDate != nil {
+				fmt.Printf("- **Target Date**: %s\n", *initiative.TargetDate)
+			}
+			fmt.Printf("- **Created**: %s\n", initiative.CreatedAt.Format("2006-01-02 15:04:05"))
+			fmt.Printf("- **Updated**: %s\n", initiative.UpdatedAt.Format("2006-01-02 15:04:05"))
+			if initiative.StartedAt != nil {
+				fmt.Printf("- **Started**: %s\n", initiative.StartedAt.Format("2006-01-02 15:04:05"))
+			}
+			if initiative.CompletedAt != nil {
+				fmt.Printf("- **Completed**: %s\n", initiative.CompletedAt.Format("2006-01-02 15:04:05"))
+			}
+			if initiative.ArchivedAt != nil {
+				fmt.Printf("- **Archived**: %s\n", initiative.ArchivedAt.Format("2006-01-02 15:04:05"))
+			}
+
+			fmt.Printf("\n## People\n")
+			if initiative.Owner != nil {
+				fmt.Printf("- **Owner**: %s (%s)\n", initiative.Owner.Name, initiative.Owner.Email)
+			} else {
+				fmt.Printf("- **Owner**: Unassigned\n")
+			}
+			if initiative.Creator != nil {
+				fmt.Printf("- **Creator**: %s (%s)\n", initiative.Creator.Name, initiative.Creator.Email)
+			}
+
+			// Hierarchy
+			if initiative.ParentInitiative != nil {
+				fmt.Printf("\n## Parent Initiative\n")
+				fmt.Printf("- **%s** (%s)\n", initiative.ParentInitiative.Name, initiative.ParentInitiative.Status)
+			}
+
+			if initiative.SubInitiatives != nil && len(initiative.SubInitiatives.Nodes) > 0 {
+				fmt.Printf("\n## Sub-Initiatives\n")
+				for _, sub := range initiative.SubInitiatives.Nodes {
+					owner := "Unassigned"
+					if sub.Owner != nil {
+						owner = sub.Owner.Name
+					}
+					fmt.Printf("- **%s** [%s] (%s)\n", sub.Name, sub.Status, owner)
+				}
+			}
+
+			// Projects
+			if initiative.Projects != nil && len(initiative.Projects.Nodes) > 0 {
+				fmt.Printf("\n## Projects (%d)\n", len(initiative.Projects.Nodes))
+				for _, project := range initiative.Projects.Nodes {
+					lead := "Unassigned"
+					if project.Lead != nil {
+						lead = project.Lead.Name
+					}
+					fmt.Printf("- **%s** [%s] (Lead: %s, Progress: %.0f%%)\n",
+						project.Name, project.State, lead, project.Progress*100)
+				}
+			}
+
+			// Initiative Updates
+			if initiative.InitiativeUpdates != nil && len(initiative.InitiativeUpdates.Nodes) > 0 {
+				fmt.Printf("\n## Recent Updates\n")
+				for _, update := range initiative.InitiativeUpdates.Nodes {
+					fmt.Printf("\n### %s by %s\n", update.CreatedAt.Format("2006-01-02 15:04"), update.User.Name)
+					fmt.Printf("- **Health**: %s\n", update.Health)
+					fmt.Printf("\n%s\n", update.Body)
+				}
+			}
+
+			fmt.Printf("\n## URL\n")
+			fmt.Printf("- %s\n", initiative.URL)
+		} else {
+			// Formatted output
+			fmt.Println()
+			fmt.Printf("%s %s\n", color.New(color.FgCyan, color.Bold).Sprint("🎯 Initiative:"), initiative.Name)
+			fmt.Println(strings.Repeat("─", 50))
+
+			fmt.Printf("%s %s\n", color.New(color.Bold).Sprint("ID:"), initiative.ID)
+
+			if initiative.Description != "" {
+				fmt.Printf("\n%s\n%s\n", color.New(color.Bold).Sprint("Description:"), initiative.Description)
+			}
+
+			statusColor := initiativeStatusColor(initiative.Status)
+			fmt.Printf("\n%s %s\n", color.New(color.Bold).Sprint("Status:"), statusColor.Sprint(initiative.Status))
+
+			if initiative.TargetDate != nil {
+				fmt.Printf("%s %s\n", color.New(color.Bold).Sprint("Target Date:"), *initiative.TargetDate)
+			}
+
+			if initiative.Owner != nil {
+				fmt.Printf("\n%s %s (%s)\n",
+					color.New(color.Bold).Sprint("Owner:"),
+					initiative.Owner.Name,
+					color.New(color.FgCyan).Sprint(initiative.Owner.Email))
+			}
+
+			// Hierarchy
+			if initiative.ParentInitiative != nil {
+				fmt.Printf("\n%s %s [%s]\n",
+					color.New(color.Bold).Sprint("Parent:"),
+					initiative.ParentInitiative.Name,
+					initiative.ParentInitiative.Status)
+			}
+
+			if initiative.SubInitiatives != nil && len(initiative.SubInitiatives.Nodes) > 0 {
+				fmt.Printf("\n%s\n", color.New(color.Bold).Sprint("Sub-Initiatives:"))
+				for _, sub := range initiative.SubInitiatives.Nodes {
+					subStatus := initiativeStatusColor(sub.Status)
+					owner := "Unassigned"
+					if sub.Owner != nil {
+						owner = sub.Owner.Name
+					}
+					fmt.Printf("  • %s %s (%s)\n",
+						subStatus.Sprint(sub.Status),
+						sub.Name,
+						color.New(color.FgWhite, color.Faint).Sprint(owner))
+				}
+			}
+
+			// Projects
+			if initiative.Projects != nil && len(initiative.Projects.Nodes) > 0 {
+				fmt.Printf("\n%s\n", color.New(color.Bold).Sprint("Projects:"))
+				for _, project := range initiative.Projects.Nodes {
+					stateColor := color.New(color.FgGreen)
+					switch project.State {
+					case "planned":
+						stateColor = color.New(color.FgCyan)
+					case "started":
+						stateColor = color.New(color.FgBlue)
+					case "paused":
+						stateColor = color.New(color.FgYellow)
+					case "completed":
+						stateColor = color.New(color.FgGreen)
+					case "canceled":
+						stateColor = color.New(color.FgRed)
+					}
+					fmt.Printf("  • %s %s\n",
+						stateColor.Sprintf("[%s]", project.State),
+						project.Name)
+				}
+			}
+
+			// Timeline
+			fmt.Printf("\n%s\n", color.New(color.Bold).Sprint("Timeline:"))
+			fmt.Printf("  Created: %s\n", initiative.CreatedAt.Format("2006-01-02"))
+			fmt.Printf("  Updated: %s\n", initiative.UpdatedAt.Format("2006-01-02"))
+			if initiative.StartedAt != nil {
+				fmt.Printf("  Started: %s\n", initiative.StartedAt.Format("2006-01-02"))
+			}
+			if initiative.CompletedAt != nil {
+				fmt.Printf("  Completed: %s\n", initiative.CompletedAt.Format("2006-01-02"))
+			}
+
+			if initiative.URL != "" {
+				fmt.Printf("\n%s %s\n",
+					color.New(color.Bold).Sprint("URL:"),
+					color.New(color.FgBlue, color.Underline).Sprint(initiative.URL))
+			}
+
+			fmt.Println()
+		}
+	},
+}
+
+var initiativeCreateCmd = &cobra.Command{
+	Use:     "create",
+	Aliases: []string{"new"},
+	Short:   "Create a new initiative",
+	Long: `Create a new initiative in Linear.
+
+Examples:
+  linctl initiative create --name "Q3 Goals"
+  linctl initiative create --name "Platform Migration" --description "Migrate to new platform" --owner me
+  linctl initiative create --name "Revenue Growth" --status Active --target-date 2024-12-31`,
+	Run: func(cmd *cobra.Command, args []string) {
+		plaintext := viper.GetBool("plaintext")
+		jsonOut := viper.GetBool("json")
+
+		authHeader, err := auth.GetAuthHeader()
+		if err != nil {
+			output.Error("Not authenticated. Run 'linctl auth' first.", plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		client := api.NewClient(authHeader)
+
+		name, _ := cmd.Flags().GetString("name")
+		if name == "" {
+			output.Error("Initiative name is required (--name)", plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		input := map[string]interface{}{
+			"name": name,
+		}
+
+		if cmd.Flags().Changed("description") {
+			description, _ := cmd.Flags().GetString("description")
+			input["description"] = description
+		}
+
+		if cmd.Flags().Changed("status") {
+			status, _ := cmd.Flags().GetString("status")
+			normalized := normalizeInitiativeStatus(status)
+			if normalized == "" {
+				output.Error(fmt.Sprintf("Invalid status '%s'. Valid statuses: Planned, Active, Completed", status), plaintext, jsonOut)
+				os.Exit(1)
+			}
+			input["status"] = normalized
+		}
+
+		if cmd.Flags().Changed("owner") {
+			ownerValue, _ := cmd.Flags().GetString("owner")
+			ownerID, err := resolveUserID(client, ownerValue)
+			if err != nil {
+				output.Error(fmt.Sprintf("Failed to resolve owner: %v", err), plaintext, jsonOut)
+				os.Exit(1)
+			}
+			input["ownerId"] = ownerID
+		}
+
+		if cmd.Flags().Changed("target-date") {
+			targetDate, _ := cmd.Flags().GetString("target-date")
+			input["targetDate"] = targetDate
+		}
+
+		if cmd.Flags().Changed("color") {
+			colorValue, _ := cmd.Flags().GetString("color")
+			input["color"] = colorValue
+		}
+
+		initiative, err := client.CreateInitiative(context.Background(), input)
+		if err != nil {
+			output.Error(fmt.Sprintf("Failed to create initiative: %v", err), plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		if jsonOut {
+			output.JSON(initiative)
+		} else if plaintext {
+			fmt.Printf("Created initiative: %s\n", initiative.Name)
+			fmt.Printf("ID: %s\n", initiative.ID)
+			fmt.Printf("URL: %s\n", initiative.URL)
+		} else {
+			fmt.Printf("%s Created initiative %s\n",
+				color.New(color.FgGreen).Sprint("✓"),
+				color.New(color.FgCyan, color.Bold).Sprint(initiative.Name))
+			fmt.Printf("  ID: %s\n", initiative.ID)
+			fmt.Printf("  URL: %s\n", color.New(color.FgBlue, color.Underline).Sprint(initiative.URL))
+		}
+	},
+}
+
+var initiativeUpdateCmd = &cobra.Command{
+	Use:   "update [initiative-id]",
+	Short: "Update an initiative",
+	Long: `Update an existing initiative's properties.
+
+Examples:
+  linctl initiative update abc123 --name "New Name"
+  linctl initiative update abc123 --status Active
+  linctl initiative update abc123 --owner me --target-date 2024-12-31`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		plaintext := viper.GetBool("plaintext")
+		jsonOut := viper.GetBool("json")
+		initiativeID := args[0]
+
+		authHeader, err := auth.GetAuthHeader()
+		if err != nil {
+			output.Error("Not authenticated. Run 'linctl auth' first.", plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		client := api.NewClient(authHeader)
+
+		input := map[string]interface{}{}
+
+		if cmd.Flags().Changed("name") {
+			name, _ := cmd.Flags().GetString("name")
+			input["name"] = name
+		}
+
+		if cmd.Flags().Changed("description") {
+			description, _ := cmd.Flags().GetString("description")
+			input["description"] = description
+		}
+
+		if cmd.Flags().Changed("status") {
+			status, _ := cmd.Flags().GetString("status")
+			normalized := normalizeInitiativeStatus(status)
+			if normalized == "" {
+				output.Error(fmt.Sprintf("Invalid status '%s'. Valid statuses: Planned, Active, Completed", status), plaintext, jsonOut)
+				os.Exit(1)
+			}
+			input["status"] = normalized
+		}
+
+		if cmd.Flags().Changed("owner") {
+			ownerValue, _ := cmd.Flags().GetString("owner")
+			if ownerValue == "none" {
+				input["ownerId"] = nil
+			} else {
+				ownerID, err := resolveUserID(client, ownerValue)
+				if err != nil {
+					output.Error(fmt.Sprintf("Failed to resolve owner: %v", err), plaintext, jsonOut)
+					os.Exit(1)
+				}
+				input["ownerId"] = ownerID
+			}
+		}
+
+		if cmd.Flags().Changed("target-date") {
+			targetDate, _ := cmd.Flags().GetString("target-date")
+			if targetDate == "" {
+				input["targetDate"] = nil
+			} else {
+				input["targetDate"] = targetDate
+			}
+		}
+
+		if cmd.Flags().Changed("color") {
+			colorValue, _ := cmd.Flags().GetString("color")
+			input["color"] = colorValue
+		}
+
+		if len(input) == 0 {
+			output.Error("No update flags provided. Use --name, --description, --status, --owner, --target-date, or --color.", plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		initiative, err := client.UpdateInitiative(context.Background(), initiativeID, input)
+		if err != nil {
+			output.Error(fmt.Sprintf("Failed to update initiative: %v", err), plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		if jsonOut {
+			output.JSON(initiative)
+		} else if plaintext {
+			fmt.Printf("Updated initiative: %s\n", initiative.Name)
+			fmt.Printf("ID: %s\n", initiative.ID)
+		} else {
+			fmt.Printf("%s Updated initiative %s\n",
+				color.New(color.FgGreen).Sprint("✓"),
+				color.New(color.FgCyan, color.Bold).Sprint(initiative.Name))
+		}
+	},
+}
+
+var initiativeDeleteCmd = &cobra.Command{
+	Use:     "delete [initiative-id]",
+	Aliases: []string{"rm", "remove"},
+	Short:   "Permanently delete an initiative",
+	Long: `Permanently delete an initiative. This cannot be undone.
+
+To soft-delete, use 'linctl initiative archive' instead.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		plaintext := viper.GetBool("plaintext")
+		jsonOut := viper.GetBool("json")
+		initiativeID := args[0]
+
+		authHeader, err := auth.GetAuthHeader()
+		if err != nil {
+			output.Error("Not authenticated. Run 'linctl auth' first.", plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		client := api.NewClient(authHeader)
+
+		// Get initiative details for confirmation
+		initiative, err := client.GetInitiative(context.Background(), initiativeID)
+		if err != nil {
+			output.Error(fmt.Sprintf("Failed to get initiative: %v", err), plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		force, _ := cmd.Flags().GetBool("force")
+		if !force && !plaintext && !jsonOut {
+			fmt.Printf("%s Are you sure you want to permanently delete initiative '%s'? This cannot be undone.\n",
+				color.New(color.FgRed).Sprint("⚠"),
+				color.New(color.Bold).Sprint(initiative.Name))
+			fmt.Print("Type 'yes' to confirm: ")
+			var confirm string
+			fmt.Scanln(&confirm)
+			if confirm != "yes" {
+				fmt.Println("Aborted.")
+				return
+			}
+		}
+
+		err = client.DeleteInitiative(context.Background(), initiativeID)
+		if err != nil {
+			output.Error(fmt.Sprintf("Failed to delete initiative: %v", err), plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		if jsonOut {
+			output.JSON(map[string]interface{}{
+				"deleted": true,
+				"id":      initiativeID,
+				"name":    initiative.Name,
+			})
+		} else if plaintext {
+			fmt.Printf("Permanently deleted initiative: %s\n", initiative.Name)
+		} else {
+			fmt.Printf("%s Permanently deleted initiative %s\n",
+				color.New(color.FgRed).Sprint("✗"),
+				color.New(color.FgCyan, color.Bold).Sprint(initiative.Name))
+		}
+	},
+}
+
+var initiativeArchiveCmd = &cobra.Command{
+	Use:   "archive [initiative-id]",
+	Short: "Archive an initiative",
+	Long:  `Archive an initiative. Archived initiatives can be restored with 'unarchive'.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		plaintext := viper.GetBool("plaintext")
+		jsonOut := viper.GetBool("json")
+		initiativeID := args[0]
+
+		authHeader, err := auth.GetAuthHeader()
+		if err != nil {
+			output.Error("Not authenticated. Run 'linctl auth' first.", plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		client := api.NewClient(authHeader)
+
+		archivedInitiative, err := client.ArchiveInitiative(context.Background(), initiativeID)
+		if err != nil {
+			output.Error(fmt.Sprintf("Failed to archive initiative: %v", err), plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		if jsonOut {
+			output.JSON(archivedInitiative)
+		} else if plaintext {
+			fmt.Printf("Archived initiative: %s\n", archivedInitiative.Name)
+		} else {
+			fmt.Printf("%s Archived initiative %s\n",
+				color.New(color.FgYellow).Sprint("📦"),
+				color.New(color.FgCyan, color.Bold).Sprint(archivedInitiative.Name))
+		}
+	},
+}
+
+var initiativeUnarchiveCmd = &cobra.Command{
+	Use:   "unarchive [initiative-id]",
+	Short: "Unarchive an initiative",
+	Long:  `Restore a previously archived initiative.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		plaintext := viper.GetBool("plaintext")
+		jsonOut := viper.GetBool("json")
+		initiativeID := args[0]
+
+		authHeader, err := auth.GetAuthHeader()
+		if err != nil {
+			output.Error("Not authenticated. Run 'linctl auth' first.", plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		client := api.NewClient(authHeader)
+
+		restoredInitiative, err := client.UnarchiveInitiative(context.Background(), initiativeID)
+		if err != nil {
+			output.Error(fmt.Sprintf("Failed to unarchive initiative: %v", err), plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		if jsonOut {
+			output.JSON(restoredInitiative)
+		} else if plaintext {
+			fmt.Printf("Unarchived initiative: %s\n", restoredInitiative.Name)
+		} else {
+			fmt.Printf("%s Unarchived initiative %s\n",
+				color.New(color.FgGreen).Sprint("✓"),
+				color.New(color.FgCyan, color.Bold).Sprint(restoredInitiative.Name))
+		}
+	},
+}
+
+var initiativeLinkCmd = &cobra.Command{
+	Use:   "link [initiative-id]",
+	Short: "Link an initiative to a project",
+	Long: `Link an initiative to a project.
+
+Examples:
+  linctl initiative link INITIATIVE-ID --project PROJECT-ID`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		plaintext := viper.GetBool("plaintext")
+		jsonOut := viper.GetBool("json")
+		initiativeID := args[0]
+
+		projectID, _ := cmd.Flags().GetString("project")
+		if projectID == "" {
+			output.Error("Project ID is required (--project)", plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		authHeader, err := auth.GetAuthHeader()
+		if err != nil {
+			output.Error("Not authenticated. Run 'linctl auth' first.", plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		client := api.NewClient(authHeader)
+
+		link, err := client.LinkInitiativeToProject(context.Background(), initiativeID, projectID)
+		if err != nil {
+			output.Error(fmt.Sprintf("Failed to link initiative to project: %v", err), plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		if jsonOut {
+			output.JSON(link)
+		} else if plaintext {
+			initName := initiativeID
+			projName := projectID
+			if link.Initiative != nil {
+				initName = link.Initiative.Name
+			}
+			if link.Project != nil {
+				projName = link.Project.Name
+			}
+			fmt.Printf("Linked initiative '%s' to project '%s'\n", initName, projName)
+		} else {
+			initName := initiativeID
+			projName := projectID
+			if link.Initiative != nil {
+				initName = link.Initiative.Name
+			}
+			if link.Project != nil {
+				projName = link.Project.Name
+			}
+			fmt.Printf("%s Linked initiative %s to project %s\n",
+				color.New(color.FgGreen).Sprint("✓"),
+				color.New(color.FgCyan, color.Bold).Sprint(initName),
+				color.New(color.FgCyan, color.Bold).Sprint(projName))
+		}
+	},
+}
+
+var initiativeUnlinkCmd = &cobra.Command{
+	Use:   "unlink [initiative-id]",
+	Short: "Unlink an initiative from a project",
+	Long: `Remove the link between an initiative and a project.
+
+Examples:
+  linctl initiative unlink INITIATIVE-ID --project PROJECT-ID`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		plaintext := viper.GetBool("plaintext")
+		jsonOut := viper.GetBool("json")
+		initiativeID := args[0]
+
+		projectID, _ := cmd.Flags().GetString("project")
+		if projectID == "" {
+			output.Error("Project ID is required (--project)", plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		authHeader, err := auth.GetAuthHeader()
+		if err != nil {
+			output.Error("Not authenticated. Run 'linctl auth' first.", plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		client := api.NewClient(authHeader)
+
+		err = client.UnlinkInitiativeFromProject(context.Background(), initiativeID, projectID)
+		if err != nil {
+			output.Error(fmt.Sprintf("Failed to unlink initiative from project: %v", err), plaintext, jsonOut)
+			os.Exit(1)
+		}
+
+		if jsonOut {
+			output.JSON(map[string]interface{}{
+				"unlinked":     true,
+				"initiativeId": initiativeID,
+				"projectId":    projectID,
+			})
+		} else if plaintext {
+			fmt.Printf("Unlinked initiative %s from project %s\n", initiativeID, projectID)
+		} else {
+			fmt.Printf("%s Unlinked initiative from project\n",
+				color.New(color.FgGreen).Sprint("✓"))
+		}
+	},
+}
+
+// normalizeInitiativeStatus normalizes a status string to the GraphQL enum value.
+// Returns empty string if the status is invalid.
+func normalizeInitiativeStatus(status string) string {
+	switch strings.ToLower(status) {
+	case "planned":
+		return "Planned"
+	case "active":
+		return "Active"
+	case "completed":
+		return "Completed"
+	default:
+		return ""
+	}
+}
+
+// initiativeStatusColor returns the color for a given initiative status.
+func initiativeStatusColor(status string) *color.Color {
+	switch status {
+	case "Planned":
+		return color.New(color.FgCyan)
+	case "Active":
+		return color.New(color.FgGreen)
+	case "Completed":
+		return color.New(color.FgBlue)
+	default:
+		return color.New(color.FgWhite)
+	}
+}
+
+// resolveUserID resolves a user identifier ("me", email, or name) to a Linear user ID.
+func resolveUserID(client *api.Client, identifier string) (string, error) {
+	if identifier == "me" {
+		viewer, err := client.GetViewer(context.Background())
+		if err != nil {
+			return "", fmt.Errorf("failed to get current user: %w", err)
+		}
+		return viewer.ID, nil
+	}
+
+	users, err := client.GetUsers(context.Background(), 100, "", "")
+	if err != nil {
+		return "", fmt.Errorf("failed to get users: %w", err)
+	}
+
+	for _, user := range users.Nodes {
+		if user.Email == identifier || user.Name == identifier {
+			return user.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("user not found: %s", identifier)
+}
+
+func init() {
+	rootCmd.AddCommand(initiativeCmd)
+	initiativeCmd.AddCommand(initiativeListCmd)
+	initiativeCmd.AddCommand(initiativeGetCmd)
+	initiativeCmd.AddCommand(initiativeCreateCmd)
+	initiativeCmd.AddCommand(initiativeUpdateCmd)
+	initiativeCmd.AddCommand(initiativeDeleteCmd)
+	initiativeCmd.AddCommand(initiativeArchiveCmd)
+	initiativeCmd.AddCommand(initiativeUnarchiveCmd)
+	initiativeCmd.AddCommand(initiativeLinkCmd)
+	initiativeCmd.AddCommand(initiativeUnlinkCmd)
+
+	// List command flags
+	initiativeListCmd.Flags().StringP("status", "s", "", "Filter by status (Planned, Active, Completed)")
+	initiativeListCmd.Flags().IntP("limit", "l", 50, "Maximum number of initiatives to return")
+	initiativeListCmd.Flags().BoolP("include-completed", "c", false, "Include completed initiatives")
+
+	// Create command flags
+	initiativeCreateCmd.Flags().String("name", "", "Initiative name (required)")
+	initiativeCreateCmd.Flags().StringP("description", "d", "", "Initiative description")
+	initiativeCreateCmd.Flags().StringP("status", "s", "", "Initial status (Planned, Active, Completed)")
+	initiativeCreateCmd.Flags().String("owner", "", "Initiative owner (email, name, or 'me')")
+	initiativeCreateCmd.Flags().String("target-date", "", "Target date (YYYY-MM-DD)")
+	initiativeCreateCmd.Flags().String("color", "", "Initiative color (hex code)")
+	_ = initiativeCreateCmd.MarkFlagRequired("name")
+
+	// Update command flags
+	initiativeUpdateCmd.Flags().String("name", "", "New initiative name")
+	initiativeUpdateCmd.Flags().StringP("description", "d", "", "New description")
+	initiativeUpdateCmd.Flags().StringP("status", "s", "", "Status (Planned, Active, Completed)")
+	initiativeUpdateCmd.Flags().String("owner", "", "Initiative owner (email, name, 'me', or 'none' to remove)")
+	initiativeUpdateCmd.Flags().String("target-date", "", "Target date (YYYY-MM-DD, or empty to remove)")
+	initiativeUpdateCmd.Flags().String("color", "", "Initiative color (hex code)")
+
+	// Delete command flags
+	initiativeDeleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
+
+	// Link command flags
+	initiativeLinkCmd.Flags().String("project", "", "Project ID to link (required)")
+	_ = initiativeLinkCmd.MarkFlagRequired("project")
+
+	// Unlink command flags
+	initiativeUnlinkCmd.Flags().String("project", "", "Project ID to unlink (required)")
+	_ = initiativeUnlinkCmd.MarkFlagRequired("project")
+}

--- a/cmd/initiative_cmd_test.go
+++ b/cmd/initiative_cmd_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestInitiativeCommandRegistration(t *testing.T) {
+	// Verify the initiative command is registered on the root command
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "initiative" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("initiative command not registered on root")
+	}
+}
+
+func TestInitiativeSubcommands(t *testing.T) {
+	expectedSubcommands := []string{
+		"list",
+		"get",
+		"create",
+		"update",
+		"delete",
+		"archive",
+		"unarchive",
+		"link",
+		"unlink",
+	}
+
+	subcommandNames := make(map[string]bool)
+	for _, cmd := range initiativeCmd.Commands() {
+		subcommandNames[cmd.Name()] = true
+	}
+
+	for _, expected := range expectedSubcommands {
+		if !subcommandNames[expected] {
+			t.Errorf("missing subcommand %q on initiative command", expected)
+		}
+	}
+}
+
+func TestInitiativeListAliases(t *testing.T) {
+	found := false
+	for _, alias := range initiativeListCmd.Aliases {
+		if alias == "ls" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("initiative list command should have 'ls' alias")
+	}
+}
+
+func TestInitiativeGetAliases(t *testing.T) {
+	found := false
+	for _, alias := range initiativeGetCmd.Aliases {
+		if alias == "show" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("initiative get command should have 'show' alias")
+	}
+}
+
+func TestInitiativeCreateFlags(t *testing.T) {
+	requiredFlags := []string{"name"}
+	for _, name := range requiredFlags {
+		flag := initiativeCreateCmd.Flags().Lookup(name)
+		if flag == nil {
+			t.Fatalf("missing required flag %q on initiative create", name)
+		}
+	}
+
+	optionalFlags := []string{"description", "status", "owner", "target-date", "color"}
+	for _, name := range optionalFlags {
+		flag := initiativeCreateCmd.Flags().Lookup(name)
+		if flag == nil {
+			t.Errorf("missing optional flag %q on initiative create", name)
+		}
+	}
+}
+
+func TestInitiativeUpdateFlags(t *testing.T) {
+	flags := []string{"name", "description", "status", "owner", "target-date", "color"}
+	for _, name := range flags {
+		flag := initiativeUpdateCmd.Flags().Lookup(name)
+		if flag == nil {
+			t.Errorf("missing flag %q on initiative update", name)
+		}
+	}
+}
+
+func TestInitiativeDeleteFlags(t *testing.T) {
+	flag := initiativeDeleteCmd.Flags().Lookup("force")
+	if flag == nil {
+		t.Fatal("missing flag 'force' on initiative delete")
+	}
+}
+
+func TestInitiativeLinkFlags(t *testing.T) {
+	flag := initiativeLinkCmd.Flags().Lookup("project")
+	if flag == nil {
+		t.Fatal("missing flag 'project' on initiative link")
+	}
+}
+
+func TestInitiativeUnlinkFlags(t *testing.T) {
+	flag := initiativeUnlinkCmd.Flags().Lookup("project")
+	if flag == nil {
+		t.Fatal("missing flag 'project' on initiative unlink")
+	}
+}
+
+func TestNormalizeInitiativeStatus(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"planned", "Planned"},
+		{"Planned", "Planned"},
+		{"PLANNED", "Planned"},
+		{"active", "Active"},
+		{"Active", "Active"},
+		{"completed", "Completed"},
+		{"invalid", ""},
+		{"", ""},
+	}
+
+	for _, tc := range tests {
+		result := normalizeInitiativeStatus(tc.input)
+		if result != tc.expected {
+			t.Errorf("normalizeInitiativeStatus(%q) = %q, want %q", tc.input, result, tc.expected)
+		}
+	}
+}

--- a/master_api_ref.md
+++ b/master_api_ref.md
@@ -5,6 +5,7 @@ Comprehensive, practical reference for Linear's GraphQL API and how `linctl` map
 Last verified against official docs: March 1, 2026.
 
 ## Canonical Sources
+
 - Developers hub: https://linear.app/developers
 - GraphQL endpoint: `https://api.linear.app/graphql`
 - Schema explorer: https://studio.apollographql.com/public/Linear-API/variant/current/explorer
@@ -13,16 +14,20 @@ Last verified against official docs: March 1, 2026.
 ## 1) Authentication
 
 ### Personal API key (common for CLI)
+
 - Header format: `Authorization: <API_KEY>`
 - Good fit for local automation and operators.
 
 ### OAuth 2.0
+
 - Header format: `Authorization: Bearer <ACCESS_TOKEN>`
 - Supported grants include user authorization flow and app-actor flow (`actor=app`).
 - Modern app capabilities include app actor tokens and app scopes.
 
 ### Current scope model (OAuth)
+
 Common scopes (workspace-specific):
+
 - `read`
 - `write`
 - `issues:create`
@@ -33,38 +38,50 @@ Common scopes (workspace-specific):
 - `app:mentionable`
 
 Notes:
+
 - Older scope lists like `issues:write` / `teams:read` are stale.
 - For older apps, follow OAuth migration guidance (refresh-token / actor updates) in the official docs.
 
 ## 2) GraphQL Conventions
 
 ### Endpoint
+
 ```text
 https://api.linear.app/graphql
 ```
 
 ### Introspection
+
 ```graphql
 query IntrospectionQuery {
   __schema {
-    queryType { name }
-    mutationType { name }
-    types { name }
+    queryType {
+      name
+    }
+    mutationType {
+      name
+    }
+    types {
+      name
+    }
   }
 }
 ```
 
 ### IDs, keys, identifiers
+
 - Most node lookups accept a Linear ID (`id`).
 - Some API paths use domain keys/identifiers (for example team key like `ENG`, issue identifier like `ENG-123`) after resolving via query logic.
 - In `linctl`, user-facing commands often accept keys/identifiers and resolve IDs internally.
 
 ### Pagination pattern
+
 - Connections use cursor pagination.
 - Standard args: `first`, `after`, `last`, `before`.
 - Standard response: `nodes` + `pageInfo { hasNextPage endCursor ... }`.
 
 ### Filtering + sorting
+
 - Filtering is typed per resource (`IssueFilter`, `ProjectFilter`, etc.).
 - Sorting is typed per resource (`IssueOrderBy`, `ProjectOrderBy`, `TeamOrderBy`, `UserOrderBy`, `CommentOrderBy`).
 - Do not assume global `PaginationOrderBy` for every query.
@@ -74,12 +91,14 @@ query IntrospectionQuery {
 Linear enforces both request-count and complexity budgets.
 
 ### Request budgets
+
 - API key: 5,000 requests/hour
 - OAuth key: 5,000 requests/hour
 - Unauthenticated: 60 requests/hour
 - Endpoint burst protection: 30 requests/minute per endpoint
 
 ### Complexity budgets
+
 - Max single request complexity: 10,000
 - API key hourly complexity budget: 3,000,000
 - OAuth hourly complexity budget: 2,000,000
@@ -88,17 +107,21 @@ Linear enforces both request-count and complexity budgets.
 Always trust live response headers for enforcement details in your workspace.
 
 ### Key response headers
+
 Request-based:
+
 - `X-RateLimit-Requests-Limit`
 - `X-RateLimit-Requests-Remaining`
 - `X-RateLimit-Requests-Reset`
 
 Complexity-based:
+
 - `X-RateLimit-Complexity-Limit`
 - `X-RateLimit-Complexity-Remaining`
 - `X-RateLimit-Complexity-Reset`
 
 Endpoint-specific (when applicable):
+
 - `X-RateLimit-Endpoint-Requests-Limit`
 - `X-RateLimit-Endpoint-Requests-Remaining`
 - `X-RateLimit-Endpoint-Requests-Reset`
@@ -108,6 +131,7 @@ Endpoint-specific (when applicable):
 Linear's GraphQL schema is broad and evolving. This section lists the practical domains you should expect to query/mutate.
 
 ### Issues
+
 - List/search/get issues
 - Create/update issues
 - Assign/delegate, set labels, parent/sub-issue links
@@ -115,21 +139,43 @@ Linear's GraphQL schema is broad and evolving. This section lists the practical 
 - Attachments, comments, SLA/triage related metadata
 
 Representative examples:
+
 ```graphql
-query Issues($filter: IssueFilter, $orderBy: IssueOrderBy, $first: Int, $after: String) {
+query Issues(
+  $filter: IssueFilter
+  $orderBy: IssueOrderBy
+  $first: Int
+  $after: String
+) {
   issues(filter: $filter, orderBy: $orderBy, first: $first, after: $after) {
     nodes {
       id
       identifier
       title
       priority
-      state { id name type color }
-      team { id key name }
-      assignee { id name email }
+      state {
+        id
+        name
+        type
+        color
+      }
+      team {
+        id
+        key
+        name
+      }
+      assignee {
+        id
+        name
+        email
+      }
       createdAt
       updatedAt
     }
-    pageInfo { hasNextPage endCursor }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
   }
 }
 ```
@@ -138,18 +184,28 @@ query Issues($filter: IssueFilter, $orderBy: IssueOrderBy, $first: Int, $after: 
 mutation IssueUpdate($id: String!, $input: IssueUpdateInput!) {
   issueUpdate(id: $id, input: $input) {
     success
-    issue { id identifier title }
+    issue {
+      id
+      identifier
+      title
+    }
   }
 }
 ```
 
 ### Projects + milestones
+
 - List/get/create/update/archive/delete projects
 - Manage lead, state, target dates, teams
 - Query milestones and link issues to milestones
 
 ```graphql
-query Projects($filter: ProjectFilter, $orderBy: ProjectOrderBy, $first: Int, $after: String) {
+query Projects(
+  $filter: ProjectFilter
+  $orderBy: ProjectOrderBy
+  $first: Int
+  $after: String
+) {
   projects(filter: $filter, orderBy: $orderBy, first: $first, after: $after) {
     nodes {
       id
@@ -158,23 +214,39 @@ query Projects($filter: ProjectFilter, $orderBy: ProjectOrderBy, $first: Int, $a
       progress
       startDate
       targetDate
-      lead { id name email }
-      teams { nodes { id key name } }
+      lead {
+        id
+        name
+        email
+      }
+      teams {
+        nodes {
+          id
+          key
+          name
+        }
+      }
     }
-    pageInfo { hasNextPage endCursor }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
   }
 }
 ```
 
 ### Initiatives + roadmap (modern planning layer)
+
 - Roadmap entities exist beyond projects (initiatives and updates).
 - Use schema explorer for exact query/mutation names and current fields in your workspace tier.
 
 ### Customers + requests (modern product feedback layer)
+
 - Customer and customer-request objects are first-class API surfaces.
 - Webhooks include customer/customerRequest events.
 
 ### Teams + workflow states
+
 - List/get teams
 - List team members
 - List/update team workflow statuses
@@ -200,40 +272,54 @@ query TeamStates($key: String!) {
 mutation WorkflowStateUpdate($id: String!, $input: WorkflowStateUpdateInput!) {
   workflowStateUpdate(id: $id, input: $input) {
     success
-    workflowState { id name type color description position }
+    workflowState {
+      id
+      name
+      type
+      color
+      description
+      position
+    }
   }
 }
 ```
 
 ### Users
+
 - Viewer/current-user query
 - Workspace user listing and lookup
 - Admin/active/guest metadata
 
 ### Labels
+
 - Team label listing
 - Create/update/delete labels
 - Parent/group label relationships
 
 ### Comments
+
 - List by issue
 - Create/get/update/delete comment
 
 ### Attachments
+
 - Create URL/PR attachments
 - Rich metadata supported via attachment input payloads
 
 ### Agent sessions + mentions
+
 - Agent session/delegation state is queryable from issue context.
 - Mentioning an agent from issue context is supported (with app scopes for agent actors where applicable).
 
 ### Webhooks
+
 - Manage webhook endpoints via API.
 - Event coverage includes classic issue/project/comment events plus modern domains (initiative, customer, customerRequest, issue SLA, and more).
 
 ## 5) Webhooks: Practical Notes
 
 ### Representative query
+
 ```graphql
 query Webhooks($first: Int, $after: String) {
   webhooks(first: $first, after: $after) {
@@ -244,12 +330,16 @@ query Webhooks($first: Int, $after: String) {
       enabled
       resourceTypes
     }
-    pageInfo { hasNextPage endCursor }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
   }
 }
 ```
 
 ### Operational guidance
+
 - Verify signatures and reject unsigned payloads.
 - Design handlers to be idempotent.
 - Expect retries and out-of-order arrivals.
@@ -258,6 +348,7 @@ query Webhooks($first: Int, $after: String) {
 ## 6) Filtering + Search Patterns
 
 ### Typical issue filter shape
+
 ```graphql
 {
   team: { id: { eq: "TEAM_ID" } }
@@ -269,6 +360,7 @@ query Webhooks($first: Int, $after: String) {
 ```
 
 ### Common comparators
+
 - `eq`, `neq`
 - `in`, `nin`
 - `contains`, `containsIgnoreCase`
@@ -282,6 +374,7 @@ Always validate exact comparator support per field/type in the schema explorer.
 `linctl` covers a focused subset of the full GraphQL surface.
 
 ### Auth
+
 ```bash
 linctl auth
 linctl auth login
@@ -291,6 +384,7 @@ linctl whoami
 ```
 
 ### Raw GraphQL
+
 ```bash
 linctl graphql [query]
 linctl graphql --query 'query { viewer { id } }'
@@ -299,6 +393,7 @@ cat query.graphql | linctl graphql --variables '{"k":"ENG"}'
 ```
 
 ### Issues
+
 ```bash
 linctl issue list|ls
 linctl issue search|find
@@ -312,6 +407,7 @@ linctl issue attachment download|dl
 ```
 
 ### Projects
+
 ```bash
 linctl project list|ls
 linctl project get|show
@@ -320,7 +416,22 @@ linctl project update
 linctl project delete|rm|remove
 ```
 
+### Initiatives
+
+```bash
+linctl initiative list|ls
+linctl initiative get|show
+linctl initiative create|new
+linctl initiative update
+linctl initiative delete|rm|remove
+linctl initiative archive
+linctl initiative unarchive
+linctl initiative link
+linctl initiative unlink
+```
+
 ### Teams
+
 ```bash
 linctl team list|ls
 linctl team get|show
@@ -330,6 +441,7 @@ linctl team status-update|state-update
 ```
 
 ### Users
+
 ```bash
 linctl user list|ls
 linctl user get|show
@@ -337,6 +449,7 @@ linctl user me
 ```
 
 ### Labels
+
 ```bash
 linctl label list|ls
 linctl label get
@@ -346,6 +459,7 @@ linctl label delete|rm|remove
 ```
 
 ### Comments
+
 ```bash
 linctl comment list|ls
 linctl comment create|add|new
@@ -355,12 +469,14 @@ linctl comment delete|rm|remove
 ```
 
 ### Agents
+
 ```bash
 linctl agent <issue-id>
 linctl agent mention <issue-id> [message...]
 ```
 
 ### Global flags
+
 - `--json, -j`
 - `--plaintext, -p`
 - `--config`
@@ -370,6 +486,7 @@ linctl agent mention <issue-id> [message...]
 ## 8) Gaps Between Full API and linctl
 
 Not all modern Linear API domains are exposed in `linctl` commands yet (for example deeper roadmap/customer/admin/app management surfaces). For unsupported flows:
+
 1. Query schema explorer for exact operation and input names.
 2. Execute the operation via `linctl graphql` so auth/config/output stay in one tool.
 3. Add CLI coverage only when workflow value is clear.
@@ -377,12 +494,14 @@ Not all modern Linear API domains are exposed in `linctl` commands yet (for exam
 ## 9) Reliability Checklist
 
 Before shipping CLI/API docs changes:
+
 1. Validate claims against official docs and schema explorer.
 2. Run `go test ./...`.
 3. For command changes, update `README.md`, `SKILL.md`, and this file in the same PR.
 4. Avoid hardcoding stale limits/scopes unless source-linked.
 
 ## Sources
+
 - https://linear.app/developers/graphql
 - https://linear.app/developers/oauth-2-0-authentication
 - https://linear.app/developers/oauth-actor-authorization

--- a/pkg/api/queries.go
+++ b/pkg/api/queries.go
@@ -241,9 +241,70 @@ type Attachments struct {
 
 // Initiative represents a Linear initiative
 type Initiative struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	ID          string     `json:"id"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	Status      string     `json:"status"`
+	SlugId      string     `json:"slugId"`
+	Color       *string    `json:"color"`
+	Icon        *string    `json:"icon"`
+	URL         string     `json:"url"`
+	TargetDate  *string    `json:"targetDate"`
+	Content     string     `json:"content"`
+	SortOrder   float64    `json:"sortOrder"`
+	CreatedAt   time.Time  `json:"createdAt"`
+	UpdatedAt   time.Time  `json:"updatedAt"`
+	ArchivedAt  *time.Time `json:"archivedAt"`
+	CompletedAt *time.Time `json:"completedAt"`
+	StartedAt   *time.Time `json:"startedAt"`
+	Creator     *User      `json:"creator"`
+	Owner       *User      `json:"owner"`
+	Projects    *Projects  `json:"projects"`
+
+	// Hierarchy
+	ParentInitiative *Initiative  `json:"parentInitiative"`
+	SubInitiatives   *Initiatives `json:"subInitiatives"`
+
+	// Updates
+	InitiativeUpdates *InitiativeUpdates `json:"initiativeUpdates"`
+}
+
+// Initiatives represents a paginated list of initiatives
+type Initiatives struct {
+	Nodes    []Initiative `json:"nodes"`
+	PageInfo PageInfo     `json:"pageInfo"`
+}
+
+// InitiativeToProject represents a link between an initiative and a project
+type InitiativeToProject struct {
+	ID         string     `json:"id"`
+	CreatedAt  time.Time  `json:"createdAt"`
+	UpdatedAt  time.Time  `json:"updatedAt"`
+	ArchivedAt *time.Time `json:"archivedAt"`
+	Project    *Project   `json:"project"`
+	Initiative *Initiative `json:"initiative"`
+	SortOrder  string     `json:"sortOrder"`
+}
+
+// InitiativeToProjects represents a paginated list of initiative-to-project links
+type InitiativeToProjects struct {
+	Nodes    []InitiativeToProject `json:"nodes"`
+	PageInfo PageInfo              `json:"pageInfo"`
+}
+
+// InitiativeUpdates represents a paginated list of initiative updates
+type InitiativeUpdates struct {
+	Nodes []InitiativeUpdateEntry `json:"nodes"`
+}
+
+// InitiativeUpdateEntry represents a status update on an initiative
+type InitiativeUpdateEntry struct {
+	ID        string    `json:"id"`
+	Body      string    `json:"body"`
+	Health    string    `json:"health"`
+	User      *User     `json:"user"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
 }
 
 type PageInfo struct {
@@ -2564,3 +2625,484 @@ func (c *Client) GetIssueRelations(ctx context.Context, issueID string) ([]Issue
 	all = append(all, response.Issue.InverseRelations.Nodes...)
 	return all, nil
 }
+
+// GetInitiatives returns a list of initiatives with optional filtering
+func (c *Client) GetInitiatives(ctx context.Context, filter map[string]interface{}, first int, after string) (*Initiatives, error) {
+	query := `
+		query Initiatives($filter: InitiativeFilter, $first: Int, $after: String) {
+			initiatives(filter: $filter, first: $first, after: $after) {
+				nodes {
+					id
+					name
+					description
+					status
+					slugId
+					url
+					targetDate
+					sortOrder
+					createdAt
+					updatedAt
+					archivedAt
+					completedAt
+					startedAt
+					creator {
+						id
+						name
+						email
+					}
+					owner {
+						id
+						name
+						email
+					}
+					projects {
+						nodes {
+							id
+							name
+							state
+						}
+					}
+				}
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"first": first,
+	}
+	if filter != nil {
+		variables["filter"] = filter
+	}
+	if after != "" {
+		variables["after"] = after
+	}
+
+	var response struct {
+		Initiatives Initiatives `json:"initiatives"`
+	}
+
+	err := c.Execute(ctx, query, variables, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.Initiatives, nil
+}
+
+// GetInitiative returns a single initiative by ID
+func (c *Client) GetInitiative(ctx context.Context, id string) (*Initiative, error) {
+	query := `
+		query Initiative($id: String!) {
+			initiative(id: $id) {
+				id
+				name
+				description
+				status
+				slugId
+				color
+				icon
+				url
+				targetDate
+				content
+				sortOrder
+				createdAt
+				updatedAt
+				archivedAt
+				completedAt
+				startedAt
+				creator {
+					id
+					name
+					email
+					avatarUrl
+					displayName
+				}
+				owner {
+					id
+					name
+					email
+					avatarUrl
+					displayName
+				}
+				projects {
+					nodes {
+						id
+						name
+						description
+						state
+						progress
+						lead {
+							name
+							email
+						}
+					}
+				}
+				parentInitiative {
+					id
+					name
+					status
+				}
+				subInitiatives {
+					nodes {
+						id
+						name
+						status
+						owner {
+							name
+						}
+					}
+				}
+				initiativeUpdates(first: 5) {
+					nodes {
+						id
+						body
+						health
+						user {
+							name
+							email
+						}
+						createdAt
+						updatedAt
+					}
+				}
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"id": id,
+	}
+
+	var response struct {
+		Initiative Initiative `json:"initiative"`
+	}
+
+	err := c.Execute(ctx, query, variables, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.Initiative, nil
+}
+
+// CreateInitiative creates a new initiative
+func (c *Client) CreateInitiative(ctx context.Context, input map[string]interface{}) (*Initiative, error) {
+	query := `
+		mutation CreateInitiative($input: InitiativeCreateInput!) {
+			initiativeCreate(input: $input) {
+				success
+				initiative {
+					id
+					name
+					description
+					status
+					slugId
+					url
+					targetDate
+					createdAt
+					updatedAt
+					owner {
+						id
+						name
+						email
+					}
+				}
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"input": input,
+	}
+
+	var response struct {
+		InitiativeCreate struct {
+			Success    bool       `json:"success"`
+			Initiative Initiative `json:"initiative"`
+		} `json:"initiativeCreate"`
+	}
+
+	err := c.Execute(ctx, query, variables, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.InitiativeCreate.Initiative, nil
+}
+
+// UpdateInitiative updates an existing initiative
+func (c *Client) UpdateInitiative(ctx context.Context, id string, input map[string]interface{}) (*Initiative, error) {
+	query := `
+		mutation UpdateInitiative($id: String!, $input: InitiativeUpdateInput!) {
+			initiativeUpdate(id: $id, input: $input) {
+				success
+				initiative {
+					id
+					name
+					description
+					status
+					slugId
+					url
+					targetDate
+					createdAt
+					updatedAt
+					owner {
+						id
+						name
+						email
+					}
+				}
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"id":    id,
+		"input": input,
+	}
+
+	var response struct {
+		InitiativeUpdate struct {
+			Success    bool       `json:"success"`
+			Initiative Initiative `json:"initiative"`
+		} `json:"initiativeUpdate"`
+	}
+
+	err := c.Execute(ctx, query, variables, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.InitiativeUpdate.Initiative, nil
+}
+
+// DeleteInitiative permanently deletes an initiative
+func (c *Client) DeleteInitiative(ctx context.Context, id string) error {
+	query := `
+		mutation DeleteInitiative($id: String!) {
+			initiativeDelete(id: $id) {
+				success
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"id": id,
+	}
+
+	var response struct {
+		InitiativeDelete struct {
+			Success bool `json:"success"`
+		} `json:"initiativeDelete"`
+	}
+
+	err := c.Execute(ctx, query, variables, &response)
+	if err != nil {
+		return err
+	}
+
+	if !response.InitiativeDelete.Success {
+		return fmt.Errorf("initiative deletion was not successful")
+	}
+
+	return nil
+}
+
+// ArchiveInitiative archives an initiative
+func (c *Client) ArchiveInitiative(ctx context.Context, id string) (*Initiative, error) {
+	query := `
+		mutation ArchiveInitiative($id: String!) {
+			initiativeArchive(id: $id) {
+				success
+				entity {
+					id
+					name
+					archivedAt
+				}
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"id": id,
+	}
+
+	var response struct {
+		InitiativeArchive struct {
+			Success bool       `json:"success"`
+			Entity  Initiative `json:"entity"`
+		} `json:"initiativeArchive"`
+	}
+
+	err := c.Execute(ctx, query, variables, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.InitiativeArchive.Entity, nil
+}
+
+// UnarchiveInitiative restores an archived initiative
+func (c *Client) UnarchiveInitiative(ctx context.Context, id string) (*Initiative, error) {
+	query := `
+		mutation UnarchiveInitiative($id: String!) {
+			initiativeUnarchive(id: $id) {
+				success
+				entity {
+					id
+					name
+					archivedAt
+				}
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"id": id,
+	}
+
+	var response struct {
+		InitiativeUnarchive struct {
+			Success bool       `json:"success"`
+			Entity  Initiative `json:"entity"`
+		} `json:"initiativeUnarchive"`
+	}
+
+	err := c.Execute(ctx, query, variables, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.InitiativeUnarchive.Entity, nil
+}
+
+// LinkInitiativeToProject links an initiative to a project
+func (c *Client) LinkInitiativeToProject(ctx context.Context, initiativeID string, projectID string) (*InitiativeToProject, error) {
+	query := `
+		mutation LinkInitiativeToProject($input: InitiativeToProjectCreateInput!) {
+			initiativeToProjectCreate(input: $input) {
+				success
+				initiativeToProject {
+					id
+					project {
+						id
+						name
+					}
+					initiative {
+						id
+						name
+					}
+				}
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"input": map[string]interface{}{
+			"initiativeId": initiativeID,
+			"projectId":    projectID,
+		},
+	}
+
+	var response struct {
+		InitiativeToProjectCreate struct {
+			Success             bool                `json:"success"`
+			InitiativeToProject InitiativeToProject `json:"initiativeToProject"`
+		} `json:"initiativeToProjectCreate"`
+	}
+
+	err := c.Execute(ctx, query, variables, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.InitiativeToProjectCreate.InitiativeToProject, nil
+}
+
+// GetInitiativeToProjectID finds the edge ID linking an initiative to a project
+func (c *Client) GetInitiativeToProjectID(ctx context.Context, initiativeID string, projectID string) (string, error) {
+	query := `
+		query InitiativeToProjects($filter: InitiativeToProjectFilter) {
+			initiativeToProjects(filter: $filter) {
+				nodes {
+					id
+					project { id }
+					initiative { id }
+				}
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"filter": map[string]interface{}{
+			"initiative": map[string]interface{}{
+				"id": map[string]interface{}{"eq": initiativeID},
+			},
+			"project": map[string]interface{}{
+				"id": map[string]interface{}{"eq": projectID},
+			},
+		},
+	}
+
+	var response struct {
+		InitiativeToProjects struct {
+			Nodes []struct {
+				ID string `json:"id"`
+			} `json:"nodes"`
+		} `json:"initiativeToProjects"`
+	}
+
+	err := c.Execute(ctx, query, variables, &response)
+	if err != nil {
+		return "", err
+	}
+
+	if len(response.InitiativeToProjects.Nodes) == 0 {
+		return "", fmt.Errorf("no link found between initiative %s and project %s", initiativeID, projectID)
+	}
+
+	return response.InitiativeToProjects.Nodes[0].ID, nil
+}
+
+// UnlinkInitiativeFromProject removes the link between an initiative and a project
+func (c *Client) UnlinkInitiativeFromProject(ctx context.Context, initiativeID string, projectID string) error {
+	// First find the edge ID
+	edgeID, err := c.GetInitiativeToProjectID(ctx, initiativeID, projectID)
+	if err != nil {
+		return err
+	}
+
+	query := `
+		mutation UnlinkInitiativeFromProject($id: String!) {
+			initiativeToProjectDelete(id: $id) {
+				success
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"id": edgeID,
+	}
+
+	var response struct {
+		InitiativeToProjectDelete struct {
+			Success bool `json:"success"`
+		} `json:"initiativeToProjectDelete"`
+	}
+
+	err = c.Execute(ctx, query, variables, &response)
+	if err != nil {
+		return err
+	}
+
+	if !response.InitiativeToProjectDelete.Success {
+		return fmt.Errorf("failed to unlink initiative from project")
+	}
+
+	return nil
+}
+


### PR DESCRIPTION
## Summary

Adds full initiative management commands to linctl, covering the Linear initiative API surface.

## New Commands

| Command | Description |
|---------|-------------|
| `linctl initiative list` | List initiatives with status/completion filtering |
| `linctl initiative get` | Rich detail view with projects, sub-initiatives, updates |
| `linctl initiative create` | Create with name, description, owner, status, target date |
| `linctl initiative update` | Update any field including owner/status/target date |
| `linctl initiative delete` | Permanent delete with confirmation |
| `linctl initiative archive` | Soft-delete (archive) |
| `linctl initiative unarchive` | Restore archived initiative |
| `linctl initiative link` | Link initiative to a project |
| `linctl initiative unlink` | Unlink initiative from project (two-step edge lookup) |

## Architecture

Follows the same patterns as `cmd/project.go`:
- Tri-mode output (table, plaintext, JSON)
- `viper` for global flag binding
- `api.Client` methods in `pkg/api/queries.go`
- Status validation against `InitiativeStatus` enum (`Planned`, `Active`, `Completed`)
- Owner resolution supporting email, name, or `me`

## Changes

- **`pkg/api/queries.go`**: Expanded `Initiative` struct (3 → 20+ fields), added `Initiatives`, `InitiativeToProject`, `InitiativeUpdates` types, and 10 API client methods
- **`cmd/initiative.go`** (new): All 9 subcommands with Cobra command definitions
- **`cmd/initiative_cmd_test.go`** (new): Unit tests for registration, flags, aliases, status normalization
- **`README.md`**: Features list, Quick Start examples, Command Reference
- **`SKILL.md`**: Command map, read/write patterns, discovery commands
- **`master_api_ref.md`**: API mapping table

## Testing

- `go build ./...` ✅
- `go test ./...` ✅ 
- `go vet ./...` ✅
- Live smoke tested against a real workspace (list, get, table/plaintext/JSON)
