### PR TITLE
Fix named Linear project statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ linctl project list --newer-than all_time
 linctl project get 65a77a62-ec5e-491e-b1d9-84aebee01b33
 
 # Create a project
-linctl project create --name "Q1 Platform" --team ENG --state started
+linctl project create --name "Q1 Platform" --team ENG --status "In Progress"
 
 # Update a project
 linctl project update PROJECT-ID --lead me --target-date 2026-06-30
@@ -563,7 +563,8 @@ linctl project create [flags]
   --name string          Project name (required)
   -t, --team strings     Team key(s) (required)
   -d, --description      Description
-  -s, --state            planned|started|paused
+  -s, --state            project status name, ID, or legacy state type
+      --status string     named project status or ID (for example, Shaping)
   --lead                 email|name|me
   --start-date           YYYY-MM-DD
   --target-date          YYYY-MM-DD
@@ -574,7 +575,8 @@ linctl project update <project-id> [flags]
 # Key flags:
   --name string
   -d, --description
-  -s, --state            planned|started|paused|completed|canceled
+  -s, --state            project status name, ID, or legacy state type
+      --status string     named project status or ID (for example, Shaping)
   --lead                 email|name|me|none
   --start-date           YYYY-MM-DD or empty to clear
   --target-date          YYYY-MM-DD or empty to clear

--- a/SKILL.md
+++ b/SKILL.md
@@ -69,6 +69,10 @@ linctl issue search "<query>" --newer-than all_time --include-completed --includ
 # Project inventory without default date filter
 linctl project list --newer-than all_time --json
 
+# Create or update a project with the exact workspace-defined status.
+linctl project create --name "Custom Properties" --team END --lead me --status "Shaping"
+linctl project update <project-id> --status "Shaping"
+
 # Team labels for resolution/validation
 linctl label list --team <TEAM_KEY> --json
 

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -47,6 +47,75 @@ func projectHasTeamKey(project api.Project, teamKey string) bool {
 	return false
 }
 
+func projectStatusLabel(project api.Project) string {
+	if project.Status != nil && project.Status.Name != "" {
+		return project.Status.Name
+	}
+	return project.State
+}
+
+func resolveProjectStatus(ctx context.Context, client *api.Client, value string) (*api.ProjectStatus, error) {
+	statuses, err := client.GetProjectStatuses(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, status := range statuses {
+		if status.ID == value || strings.EqualFold(status.Name, value) {
+			return &status, nil
+		}
+	}
+
+	matchingTypes := make([]api.ProjectStatus, 0, 1)
+	for _, status := range statuses {
+		if strings.EqualFold(status.Type, value) {
+			matchingTypes = append(matchingTypes, status)
+		}
+	}
+	if len(matchingTypes) == 1 {
+		return &matchingTypes[0], nil
+	}
+	if len(matchingTypes) > 1 {
+		return nil, fmt.Errorf("project state type %q is ambiguous; use a named status: %s", value, projectStatusNames(matchingTypes))
+	}
+
+	return nil, fmt.Errorf("project status %q was not found; available statuses: %s", value, projectStatusNames(statuses))
+}
+
+func projectStatusNames(statuses []api.ProjectStatus) string {
+	names := make([]string, 0, len(statuses))
+	for _, status := range statuses {
+		names = append(names, status.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
+func addProjectStatusInput(ctx context.Context, cmd *cobra.Command, client *api.Client, input map[string]interface{}) error {
+	statusChanged := cmd.Flags().Changed("status")
+	stateChanged := cmd.Flags().Changed("state")
+	if statusChanged && stateChanged {
+		return fmt.Errorf("use only one of --status or --state")
+	}
+	if !statusChanged && !stateChanged {
+		return nil
+	}
+
+	flagName := "status"
+	if stateChanged {
+		flagName = "state"
+	}
+	value, err := cmd.Flags().GetString(flagName)
+	if err != nil {
+		return err
+	}
+	status, err := resolveProjectStatus(ctx, client, value)
+	if err != nil {
+		return err
+	}
+	input["statusId"] = status.ID
+	return nil
+}
+
 // projectCmd represents the project command
 var projectCmd = &cobra.Command{
 	Use:   "project",
@@ -188,7 +257,7 @@ var projectListCmd = &cobra.Command{
 			for _, project := range projects.Nodes {
 				fmt.Printf("## %s\n", project.Name)
 				fmt.Printf("- **ID**: %s\n", project.ID)
-				fmt.Printf("- **State**: %s\n", project.State)
+				fmt.Printf("- **State**: %s\n", projectStatusLabel(project))
 				fmt.Printf("- **Progress**: %.0f%%\n", project.Progress*100)
 				if project.Lead != nil {
 					fmt.Printf("- **Lead**: %s\n", project.Lead.Name)
@@ -258,7 +327,7 @@ var projectListCmd = &cobra.Command{
 
 				rows = append(rows, []string{
 					truncateString(project.Name, 25),
-					stateColor.Sprint(project.State),
+					stateColor.Sprint(projectStatusLabel(project)),
 					lead,
 					teams,
 					project.CreatedAt.Format("2006-01-02"),
@@ -326,7 +395,7 @@ var projectGetCmd = &cobra.Command{
 			fmt.Printf("## Core Details\n")
 			fmt.Printf("- **ID**: %s\n", project.ID)
 			fmt.Printf("- **Slug ID**: %s\n", project.SlugId)
-			fmt.Printf("- **State**: %s\n", project.State)
+			fmt.Printf("- **State**: %s\n", projectStatusLabel(*project))
 			fmt.Printf("- **Progress**: %.0f%%\n", project.Progress*100)
 			fmt.Printf("- **Health**: %s\n", project.Health)
 			fmt.Printf("- **Scope**: %d\n", project.Scope)
@@ -534,7 +603,7 @@ var projectGetCmd = &cobra.Command{
 			case "canceled":
 				stateColor = color.New(color.FgRed)
 			}
-			fmt.Printf("\n%s %s\n", color.New(color.Bold).Sprint("State:"), stateColor.Sprint(project.State))
+			fmt.Printf("\n%s %s\n", color.New(color.Bold).Sprint("State:"), stateColor.Sprint(projectStatusLabel(*project)))
 
 			progressColor := color.New(color.FgRed)
 			if project.Progress >= 0.75 {
@@ -643,7 +712,7 @@ Examples:
   linctl project create --name "Q1 Release" --team ENG
   linctl project create --name "Auth Overhaul" --team ENG --description "Rewrite authentication system"
   linctl project create --name "Mobile App" --team ENG --lead me --start-date 2024-01-01 --target-date 2024-06-30
-  linctl project create --name "Bug Bash" --team ENG,QA --state started`,
+  linctl project create --name "Bug Bash" --team ENG,QA --status "Shaping"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		plaintext := viper.GetBool("plaintext")
 		jsonOut := viper.GetBool("json")
@@ -693,21 +762,9 @@ Examples:
 			input["description"] = description
 		}
 
-		if cmd.Flags().Changed("state") {
-			state, _ := cmd.Flags().GetString("state")
-			validStates := []string{"planned", "started", "paused", "completed", "canceled"}
-			isValid := false
-			for _, vs := range validStates {
-				if strings.EqualFold(state, vs) {
-					input["state"] = strings.ToLower(state)
-					isValid = true
-					break
-				}
-			}
-			if !isValid {
-				output.Error(fmt.Sprintf("Invalid state '%s'. Valid states: %s", state, strings.Join(validStates, ", ")), plaintext, jsonOut)
-				os.Exit(1)
-			}
+		if err := addProjectStatusInput(context.Background(), cmd, client, input); err != nil {
+			output.Error(fmt.Sprintf("Failed to resolve project status: %v", err), plaintext, jsonOut)
+			os.Exit(1)
 		}
 
 		if cmd.Flags().Changed("lead") {
@@ -787,7 +844,7 @@ var projectUpdateCmd = &cobra.Command{
 Examples:
   linctl project update abc123 --name "New Name"
   linctl project update abc123 --description "Updated description"
-  linctl project update abc123 --state started
+  linctl project update abc123 --status "Shaping"
   linctl project update abc123 --lead john@company.com
   linctl project update abc123 --target-date 2024-12-31
   linctl project update abc123 --state completed`,
@@ -818,21 +875,9 @@ Examples:
 			input["description"] = description
 		}
 
-		if cmd.Flags().Changed("state") {
-			state, _ := cmd.Flags().GetString("state")
-			validStates := []string{"planned", "started", "paused", "completed", "canceled"}
-			isValid := false
-			for _, vs := range validStates {
-				if strings.EqualFold(state, vs) {
-					input["state"] = strings.ToLower(state)
-					isValid = true
-					break
-				}
-			}
-			if !isValid {
-				output.Error(fmt.Sprintf("Invalid state '%s'. Valid states: %s", state, strings.Join(validStates, ", ")), plaintext, jsonOut)
-				os.Exit(1)
-			}
+		if err := addProjectStatusInput(context.Background(), cmd, client, input); err != nil {
+			output.Error(fmt.Sprintf("Failed to resolve project status: %v", err), plaintext, jsonOut)
+			os.Exit(1)
 		}
 
 		if cmd.Flags().Changed("lead") {
@@ -1040,7 +1085,8 @@ func init() {
 	projectCreateCmd.Flags().String("name", "", "Project name (required)")
 	projectCreateCmd.Flags().StringSliceP("team", "t", []string{}, "Team key(s) (required, comma-separated for multiple)")
 	projectCreateCmd.Flags().StringP("description", "d", "", "Project description")
-	projectCreateCmd.Flags().StringP("state", "s", "", "Initial state (planned, started, paused)")
+	projectCreateCmd.Flags().StringP("state", "s", "", "Initial project status name, ID, or legacy state type")
+	projectCreateCmd.Flags().String("status", "", "Initial named project status or ID (for example, Shaping)")
 	projectCreateCmd.Flags().String("lead", "", "Project lead (email, name, or 'me')")
 	projectCreateCmd.Flags().String("start-date", "", "Start date (YYYY-MM-DD)")
 	projectCreateCmd.Flags().String("target-date", "", "Target date (YYYY-MM-DD)")
@@ -1051,7 +1097,8 @@ func init() {
 	// Update command flags
 	projectUpdateCmd.Flags().String("name", "", "New project name")
 	projectUpdateCmd.Flags().StringP("description", "d", "", "New description")
-	projectUpdateCmd.Flags().StringP("state", "s", "", "State (planned, started, paused, completed, canceled)")
+	projectUpdateCmd.Flags().StringP("state", "s", "", "Project status name, ID, or legacy state type")
+	projectUpdateCmd.Flags().String("status", "", "Named project status or ID (for example, Shaping)")
 	projectUpdateCmd.Flags().String("lead", "", "Project lead (email, name, 'me', or 'none' to remove)")
 	projectUpdateCmd.Flags().String("start-date", "", "Start date (YYYY-MM-DD, or empty to remove)")
 	projectUpdateCmd.Flags().String("target-date", "", "Target date (YYYY-MM-DD, or empty to remove)")

--- a/cmd/project_cmd_test.go
+++ b/cmd/project_cmd_test.go
@@ -12,7 +12,7 @@ import (
 
 func resetProjectUpdateFlags(t *testing.T) {
 	t.Helper()
-	for _, name := range []string{"name", "description", "state", "lead", "start-date", "target-date", "color", "content"} {
+	for _, name := range []string{"name", "description", "state", "status", "lead", "start-date", "target-date", "color", "content"} {
 		flag := projectUpdateCmd.Flags().Lookup(name)
 		if flag == nil {
 			t.Fatalf("missing flag %q", name)

--- a/cmd/project_status_test.go
+++ b/cmd/project_status_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dorkitude/linctl/pkg/api"
+)
+
+func TestResolveProjectStatusByName(t *testing.T) {
+	client := projectStatusTestClient(t, `[{"id":"status-shaping","name":"Shaping","type":"backlog","color":"#95a2b3","position":1}]`)
+
+	status, err := resolveProjectStatus(context.Background(), client, "shaping")
+	if err != nil {
+		t.Fatalf("resolveProjectStatus returned error: %v", err)
+	}
+	if status.ID != "status-shaping" {
+		t.Fatalf("expected Shaping status ID, got %q", status.ID)
+	}
+}
+
+func TestResolveProjectStatusRejectsAmbiguousType(t *testing.T) {
+	client := projectStatusTestClient(t, `[{"id":"status-progress","name":"In Progress","type":"started","color":"#95a2b3","position":1},{"id":"status-review","name":"In Review","type":"started","color":"#95a2b3","position":2}]`)
+
+	_, err := resolveProjectStatus(context.Background(), client, "started")
+	if err == nil {
+		t.Fatal("expected ambiguous status type to fail")
+	}
+	if !strings.Contains(err.Error(), "use a named status") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func projectStatusTestClient(t *testing.T, statuses string) *api.Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req gqlCommandTestRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if !strings.Contains(req.Query, "query ProjectStatuses") {
+			t.Fatalf("expected ProjectStatuses query, got: %s", req.Query)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"projectStatuses":{"nodes":` + statuses + `}}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return api.NewClientWithURL(srv.URL, "Bearer test")
+}

--- a/pkg/api/project_status_test.go
+++ b/pkg/api/project_status_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGetProjectStatuses(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req gqlTestRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if !strings.Contains(req.Query, "query ProjectStatuses") {
+			t.Fatalf("expected ProjectStatuses query, got: %s", req.Query)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"projectStatuses":{"nodes":[{"id":"status-shaping","name":"Shaping","type":"backlog","color":"#95a2b3","position":1}]}}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithURL(srv.URL, "Bearer test")
+	statuses, err := c.GetProjectStatuses(context.Background())
+	if err != nil {
+		t.Fatalf("GetProjectStatuses returned error: %v", err)
+	}
+	if len(statuses) != 1 {
+		t.Fatalf("expected one status, got %d", len(statuses))
+	}
+	if got := statuses[0]; got.ID != "status-shaping" || got.Name != "Shaping" || got.Type != "backlog" {
+		t.Fatalf("unexpected status: %+v", got)
+	}
+}

--- a/pkg/api/queries.go
+++ b/pkg/api/queries.go
@@ -97,26 +97,27 @@ type State struct {
 
 // Project represents a Linear project
 type Project struct {
-	ID          string     `json:"id"`
-	Name        string     `json:"name"`
-	Description string     `json:"description"`
-	State       string     `json:"state"`
-	Progress    float64    `json:"progress"`
-	StartDate   *string    `json:"startDate"`
-	TargetDate  *string    `json:"targetDate"`
-	Lead        *User      `json:"lead"`
-	Teams       *Teams     `json:"teams"`
-	URL         string     `json:"url"`
-	Icon        *string    `json:"icon"`
-	Color       string     `json:"color"`
-	CreatedAt   time.Time  `json:"createdAt"`
-	UpdatedAt   time.Time  `json:"updatedAt"`
-	CompletedAt *time.Time `json:"completedAt"`
-	CanceledAt  *time.Time `json:"canceledAt"`
-	ArchivedAt  *time.Time `json:"archivedAt"`
-	Creator     *User      `json:"creator"`
-	Members     *Users     `json:"members"`
-	Issues      *Issues    `json:"issues"`
+	ID          string         `json:"id"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	State       string         `json:"state"`
+	Status      *ProjectStatus `json:"status"`
+	Progress    float64        `json:"progress"`
+	StartDate   *string        `json:"startDate"`
+	TargetDate  *string        `json:"targetDate"`
+	Lead        *User          `json:"lead"`
+	Teams       *Teams         `json:"teams"`
+	URL         string         `json:"url"`
+	Icon        *string        `json:"icon"`
+	Color       string         `json:"color"`
+	CreatedAt   time.Time      `json:"createdAt"`
+	UpdatedAt   time.Time      `json:"updatedAt"`
+	CompletedAt *time.Time     `json:"completedAt"`
+	CanceledAt  *time.Time     `json:"canceledAt"`
+	ArchivedAt  *time.Time     `json:"archivedAt"`
+	Creator     *User          `json:"creator"`
+	Members     *Users         `json:"members"`
+	Issues      *Issues        `json:"issues"`
 	// Additional fields
 	SlugId              string          `json:"slugId"`
 	Content             string          `json:"content"`
@@ -129,6 +130,17 @@ type Project struct {
 	SlackNewIssue       bool            `json:"slackNewIssue"`
 	SlackIssueComments  bool            `json:"slackIssueComments"`
 	SlackIssueStatuses  bool            `json:"slackIssueStatuses"`
+}
+
+// ProjectStatus is the workspace-defined status assigned to a project.
+// State is its broad Linear type (for example, backlog); Name is the
+// workspace-specific label (for example, Shaping).
+type ProjectStatus struct {
+	ID       string  `json:"id"`
+	Name     string  `json:"name"`
+	Type     string  `json:"type"`
+	Color    string  `json:"color"`
+	Position float64 `json:"position"`
 }
 
 // Paginated collections
@@ -719,10 +731,17 @@ func (c *Client) GetIssue(ctx context.Context, id string) (*Issue, error) {
 				}
 				project {
 					id
+				name
+				description
+				state
+				status {
+					id
 					name
-					description
-					state
-					progress
+					type
+					color
+					position
+				}
+				progress
 					startDate
 					targetDate
 					health
@@ -1003,12 +1022,19 @@ func (c *Client) GetProjects(ctx context.Context, filter map[string]interface{},
 	query := `
 		query Projects($filter: ProjectFilter, $first: Int, $after: String, $orderBy: PaginationOrderBy) {
 			projects(filter: $filter, first: $first, after: $after, orderBy: $orderBy) {
-				nodes {
-					id
-					name
-					description
-					state
-					progress
+					nodes {
+						id
+						name
+						description
+						state
+						status {
+							id
+							name
+							type
+							color
+							position
+						}
+						progress
 					startDate
 					targetDate
 					url
@@ -1071,6 +1097,13 @@ func (c *Client) GetProject(ctx context.Context, id string) (*Project, error) {
 				description
 				content
 				state
+				status {
+					id
+					name
+					type
+					color
+					position
+				}
 				progress
 				health
 				scope
@@ -1217,6 +1250,35 @@ func (c *Client) GetProject(ctx context.Context, id string) (*Project, error) {
 	return &response.Project, nil
 }
 
+// GetProjectStatuses returns the workspace-defined statuses available to projects.
+func (c *Client) GetProjectStatuses(ctx context.Context) ([]ProjectStatus, error) {
+	query := `
+		query ProjectStatuses {
+			projectStatuses {
+				nodes {
+					id
+					name
+					type
+					color
+					position
+				}
+			}
+		}
+	`
+
+	var response struct {
+		ProjectStatuses struct {
+			Nodes []ProjectStatus `json:"nodes"`
+		} `json:"projectStatuses"`
+	}
+
+	if err := c.Execute(ctx, query, nil, &response); err != nil {
+		return nil, err
+	}
+
+	return response.ProjectStatuses.Nodes, nil
+}
+
 // GetProjectMilestones returns all milestones for a specific project.
 func (c *Client) GetProjectMilestones(ctx context.Context, projectID string) ([]ProjectMilestone, error) {
 	query := `
@@ -1288,6 +1350,13 @@ func (c *Client) CreateProject(ctx context.Context, input map[string]interface{}
 					name
 					description
 					state
+					status {
+						id
+						name
+						type
+						color
+						position
+					}
 					progress
 					startDate
 					targetDate
@@ -1344,6 +1413,13 @@ func (c *Client) UpdateProject(ctx context.Context, id string, input map[string]
 					description
 					content
 					state
+					status {
+						id
+						name
+						type
+						color
+						position
+					}
 					progress
 					startDate
 					targetDate


### PR DESCRIPTION
## Summary
- add exact project status selection with `--status <name-or-id>`
- resolve legacy `--state` values through workspace project statuses and reject ambiguous types
- return and display the named status alongside Linear's generic status type

## Verification
- `go test ./...`
- live `go run . project update <project-id> --status Shaping --json` followed by `project get` confirms `status.name` is `Shaping`