### PR TITLE
fix(relation): correct inverted `blocks` direction in read and write paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,36 @@ tags, PR merge commits, and tag-to-tag commit history.
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected the `blocks` direction across `linctl issue relation`, which was
+  built on an inverted reading of Linear's API. For `type: "blocks"` the `issue`
+  field is the blocker and `relatedIssue` is the blocked issue; the code assumed
+  the reverse. Three user-visible consequences are fixed ([#57]):
+  - `relation add --blocks` / `--blocked-by` stored the opposite relation from
+    the one requested, while the confirmation message reported the requested
+    direction — so the error was invisible from the CLI.
+  - `relation list` labelled blocking relations backwards, reporting the blocker
+    as "blocked by" its own dependent.
+  - `relation list` named the queried issue as its own counterpart for inverse
+    relations, because `relationOtherIssue` ignored the `Inverse` flag.
+- Note for existing users: relations created through earlier versions of
+  `relation add --blocks` are stored inverted in Linear. This release changes
+  what future writes mean relative to that data; verify existing blocking edges
+  in the Linear web UI or via `relation list -j`.
+
+### Changed
+
+- Relation tests previously asserted the inverted behaviour, which is why the
+  bug survived. They are updated to the corrected directions, and gain coverage
+  for inverse-relation counterpart selection and read-direction symmetry.
+
 ### Docs
 
 - Added `CHANGELOG.md` and release guidance for maintaining it.
+- Documented relation direction explicitly in the README relation section.
+
+[#57]: https://github.com/dorkitude/linctl/issues/57
 
 ## [v0.1.10] - 2026-06-25
 

--- a/README.md
+++ b/README.md
@@ -493,6 +493,14 @@ linctl issue relation add LIN-123 --blocked-by LIN-456   # LIN-123 is blocked by
 linctl issue relation list LIN-123 -j                    # JSON output for scripting
 ```
 
+**Direction.** `--blocks` makes the issue you name in the command the blocker;
+`--blocked-by` makes it the blocked one. `relation list` describes each edge from
+the point of view of the issue you queried, so a single edge reads `blocks` from
+the blocker's end and `blocked by` from the other end, each line naming the
+issue at the far end. In `-j` output the raw shape is
+`issue --type--> relatedIssue`, i.e. for `"blocks"` the `issue` field is the
+blocker.
+
 ### Agent Commands
 ```bash
 # View agent delegation/session for an issue

--- a/cmd/relation.go
+++ b/cmd/relation.go
@@ -195,16 +195,17 @@ Examples:
 
 		// Map the CLI relation type to the Linear API type.
 		// Linear's issueRelationCreate uses:
-		//   issueId = the issue that has the relation
-		//   relatedIssueId = the other issue
-		//   type = "blocks" means issueId is blocked by relatedIssueId
+		//   issueId = the source issue the relation originates from
+		//   relatedIssueId = the target issue
+		//   type describes how the source relates to the target, so
+		//   type = "blocks" means issueId blocks relatedIssueId
 		//
 		// CLI semantics:
 		//   --blocks TARGET     => "this issue blocks TARGET"
-		//                       => TARGET is blocked by THIS
-		//                       => API: issueId=TARGET, relatedIssueId=THIS, type=blocks
+		//                       => API: issueId=THIS, relatedIssueId=TARGET, type=blocks
 		//   --blocked-by SOURCE => "this issue is blocked by SOURCE"
-		//                       => API: issueId=THIS, relatedIssueId=SOURCE, type=blocks
+		//                       => SOURCE blocks THIS
+		//                       => API: issueId=SOURCE, relatedIssueId=THIS, type=blocks
 		//   --related TARGET    => API: issueId=THIS, relatedIssueId=TARGET, type=related
 		//   --duplicate TARGET  => API: issueId=THIS, relatedIssueId=TARGET, type=duplicate
 
@@ -212,14 +213,14 @@ Examples:
 
 		switch relationType {
 		case "blocks":
-			// "LIN-123 blocks LIN-456" => LIN-456 is blocked by LIN-123
-			apiIssueID = relatedIssue.ID
-			apiRelatedIssueID = issue.ID
-			apiType = "blocks"
-		case "blocked-by":
-			// "LIN-123 is blocked by LIN-456" => LIN-123 is blocked by LIN-456
+			// "LIN-123 blocks LIN-456" => LIN-123 is the blocker
 			apiIssueID = issue.ID
 			apiRelatedIssueID = relatedIssue.ID
+			apiType = "blocks"
+		case "blocked-by":
+			// "LIN-123 is blocked by LIN-456" => LIN-456 is the blocker
+			apiIssueID = relatedIssue.ID
+			apiRelatedIssueID = issue.ID
 			apiType = "blocks"
 		case "related":
 			apiIssueID = issue.ID
@@ -311,28 +312,39 @@ Examples:
 	},
 }
 
-// relationOtherIssue returns the "other" issue in a relation — either Issue or
-// RelatedIssue, whichever is populated.
+// relationOtherIssue returns the counterpart of the queried issue in a relation.
+//
+// For a forward relation the queried issue is Issue, so the counterpart is
+// RelatedIssue. For an inverse relation (fetched via inverseRelations) the
+// queried issue is RelatedIssue, so the counterpart is Issue. The GraphQL query
+// selects both sides on both edges, so choosing on Inverse — not on which field
+// happens to be populated — is what keeps this from returning the issue the
+// caller asked about.
 func relationOtherIssue(rel *api.IssueRelation) *api.Issue {
-	if rel.RelatedIssue != nil {
-		return rel.RelatedIssue
+	first, second := rel.RelatedIssue, rel.Issue
+	if rel.Inverse {
+		first, second = rel.Issue, rel.RelatedIssue
 	}
-	if rel.Issue != nil {
-		return rel.Issue
+	if first != nil {
+		return first
+	}
+	if second != nil {
+		return second
 	}
 	return &api.Issue{Identifier: "?", Title: "unknown"}
 }
 
 // relationTypeLabel returns a human-readable label for a relation type.
-// When inverse is true, the label is flipped to reflect the opposite direction
-// (e.g. "blocks" instead of "blocked by").
+// The label describes the queried issue as the subject acting on the
+// counterpart. When inverse is true the queried issue is the target of the
+// relation, so the label is flipped (e.g. "blocked by" instead of "blocks").
 func relationTypeLabel(t string, inverse bool) string {
 	switch strings.ToLower(t) {
 	case "blocks":
 		if inverse {
-			return "blocks"
+			return "blocked by"
 		}
-		return "blocked by"
+		return "blocks"
 	case "duplicate":
 		if inverse {
 			return "has duplicate"

--- a/cmd/relation_cmd_test.go
+++ b/cmd/relation_cmd_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dorkitude/linctl/pkg/api"
 	"github.com/spf13/viper"
 )
 
@@ -69,7 +70,7 @@ func TestRelationAddBlocksSendsCorrectMutation(t *testing.T) {
 				t.Fatalf("expected input map, got %#v", gqlReq.Variables["input"])
 			}
 			capturedInput = input
-			body := `{"data":{"issueRelationCreate":{"success":true,"issueRelation":{"id":"rel-1","type":"blocks","issue":{"id":"uuid-200","identifier":"LIN-200","title":"Child issue"},"relatedIssue":{"id":"uuid-100","identifier":"LIN-100","title":"Parent issue"}}}}}`
+			body := `{"data":{"issueRelationCreate":{"success":true,"issueRelation":{"id":"rel-1","type":"blocks","issue":{"id":"uuid-100","identifier":"LIN-100","title":"Parent issue"},"relatedIssue":{"id":"uuid-200","identifier":"LIN-200","title":"Child issue"}}}}}`
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     make(http.Header),
@@ -81,18 +82,19 @@ func TestRelationAddBlocksSendsCorrectMutation(t *testing.T) {
 		return nil, nil
 	})
 
-	// "LIN-100 --blocks LIN-200" means LIN-100 blocks LIN-200
-	// => LIN-200 is blocked by LIN-100
-	// => API: issueId=LIN-200 (uuid-200), relatedIssueId=LIN-100 (uuid-100), type=blocks
+	// "LIN-100 --blocks LIN-200" means LIN-100 blocks LIN-200.
+	// Linear's type describes how the source relates to the target, so the
+	// blocker is the source: issueId=LIN-100 (uuid-100),
+	// relatedIssueId=LIN-200 (uuid-200), type=blocks.
 	issueRelationAddCmd.Flags().Set("blocks", "LIN-200")
 	issueRelationAddCmd.Run(issueRelationAddCmd, []string{"LIN-100"})
 
-	// Verify the API was called with the correct swapped IDs
-	if capturedInput["issueId"] != "uuid-200" {
-		t.Fatalf("expected issueId=uuid-200 (the blocked issue), got %v", capturedInput["issueId"])
+	// Verify the blocker is sent as the source issue, not the target
+	if capturedInput["issueId"] != "uuid-100" {
+		t.Fatalf("expected issueId=uuid-100 (the blocker), got %v", capturedInput["issueId"])
 	}
-	if capturedInput["relatedIssueId"] != "uuid-100" {
-		t.Fatalf("expected relatedIssueId=uuid-100 (the blocker), got %v", capturedInput["relatedIssueId"])
+	if capturedInput["relatedIssueId"] != "uuid-200" {
+		t.Fatalf("expected relatedIssueId=uuid-200 (the blocked issue), got %v", capturedInput["relatedIssueId"])
 	}
 	if capturedInput["type"] != "blocks" {
 		t.Fatalf("expected type=blocks, got %v", capturedInput["type"])
@@ -137,7 +139,7 @@ func TestRelationAddBlockedBySendsCorrectMutation(t *testing.T) {
 				t.Fatalf("expected input map, got %#v", gqlReq.Variables["input"])
 			}
 			capturedInput = input
-			body := `{"data":{"issueRelationCreate":{"success":true,"issueRelation":{"id":"rel-2","type":"blocks","issue":{"id":"uuid-100","identifier":"LIN-100","title":"Blocked issue"},"relatedIssue":{"id":"uuid-200","identifier":"LIN-200","title":"Blocker issue"}}}}}`
+			body := `{"data":{"issueRelationCreate":{"success":true,"issueRelation":{"id":"rel-2","type":"blocks","issue":{"id":"uuid-200","identifier":"LIN-200","title":"Blocker issue"},"relatedIssue":{"id":"uuid-100","identifier":"LIN-100","title":"Blocked issue"}}}}}`
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     make(http.Header),
@@ -149,23 +151,28 @@ func TestRelationAddBlockedBySendsCorrectMutation(t *testing.T) {
 		return nil, nil
 	})
 
-	// "LIN-100 --blocked-by LIN-200" means LIN-100 is blocked by LIN-200
-	// => API: issueId=LIN-100 (uuid-100), relatedIssueId=LIN-200 (uuid-200), type=blocks
+	// "LIN-100 --blocked-by LIN-200" means LIN-200 blocks LIN-100, so LIN-200 is
+	// the source: issueId=LIN-200 (uuid-200), relatedIssueId=LIN-100 (uuid-100),
+	// type=blocks.
 	issueRelationAddCmd.Flags().Set("blocked-by", "LIN-200")
 	issueRelationAddCmd.Run(issueRelationAddCmd, []string{"LIN-100"})
 
-	if capturedInput["issueId"] != "uuid-100" {
-		t.Fatalf("expected issueId=uuid-100, got %v", capturedInput["issueId"])
+	if capturedInput["issueId"] != "uuid-200" {
+		t.Fatalf("expected issueId=uuid-200 (the blocker), got %v", capturedInput["issueId"])
 	}
-	if capturedInput["relatedIssueId"] != "uuid-200" {
-		t.Fatalf("expected relatedIssueId=uuid-200, got %v", capturedInput["relatedIssueId"])
+	if capturedInput["relatedIssueId"] != "uuid-100" {
+		t.Fatalf("expected relatedIssueId=uuid-100 (the blocked issue), got %v", capturedInput["relatedIssueId"])
 	}
 	if capturedInput["type"] != "blocks" {
 		t.Fatalf("expected type=blocks, got %v", capturedInput["type"])
 	}
 }
 
-func TestRelationListShowsRelations(t *testing.T) {
+// runRelationList runs 'issue relation list' in plaintext mode against a mocked
+// IssueRelations response and returns everything written to stdout.
+func runRelationList(t *testing.T, issueID, body string) string {
+	t.Helper()
+
 	origTransport := http.DefaultTransport
 	defer func() { http.DefaultTransport = origTransport }()
 	t.Setenv("LINCTL_API_KEY", "test-key")
@@ -177,22 +184,9 @@ func TestRelationListShowsRelations(t *testing.T) {
 		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-
 		if !strings.Contains(gqlReq.Query, "IssueRelations") {
 			t.Fatalf("expected IssueRelations query, got: %s", gqlReq.Query)
 		}
-
-		// Return one forward "blocks" relation (this issue is blocked by LIN-200)
-		// and one inverse "blocks" relation (this issue blocks LIN-300).
-		// The labels should differ: "blocked by" vs "blocks".
-		body := `{"data":{"issue":{
-			"relations":{"nodes":[
-				{"id":"rel-1","type":"blocks","issue":{"id":"uuid-100","identifier":"LIN-100","title":"This issue"},"relatedIssue":{"id":"uuid-200","identifier":"LIN-200","title":"Blocker task"}}
-			]},
-			"inverseRelations":{"nodes":[
-				{"id":"rel-2","type":"blocks","issue":{"id":"uuid-300","identifier":"LIN-300","title":"Blocked task"},"relatedIssue":{"id":"uuid-100","identifier":"LIN-100","title":"This issue"}}
-			]}
-		}}}`
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     make(http.Header),
@@ -200,34 +194,154 @@ func TestRelationListShowsRelations(t *testing.T) {
 		}, nil
 	})
 
-	// Capture stdout to verify direction-aware labels
 	oldStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	issueRelationListCmd.Run(issueRelationListCmd, []string{"LIN-100"})
+	issueRelationListCmd.Run(issueRelationListCmd, []string{issueID})
 
 	w.Close()
 	var buf strings.Builder
 	io.Copy(&buf, r)
 	os.Stdout = oldStdout
-	got := buf.String()
+	return buf.String()
+}
 
-	// Forward "blocks" relation should display as "blocked by"
-	if !strings.Contains(got, "blocked by") {
-		t.Fatalf("expected forward blocks relation labeled 'blocked by', got:\n%s", got)
-	}
-	// Inverse "blocks" relation should display as "blocks" (not "blocked by")
-	lines := strings.Split(got, "\n")
-	var secondLabel string
-	for _, line := range lines {
-		if strings.Contains(line, "rel-2") {
-			secondLabel = line
-			break
+// relationLine returns the plaintext output line describing the given relation ID.
+func relationLine(t *testing.T, out, relationID string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, relationID) {
+			return line
 		}
 	}
-	if !strings.Contains(secondLabel, "blocks") || strings.Contains(secondLabel, "blocked by") {
-		t.Fatalf("expected inverse blocks relation labeled 'blocks', got:\n%s", got)
+	t.Fatalf("no output line for relation %q in:\n%s", relationID, out)
+	return ""
+}
+
+func TestRelationListShowsRelations(t *testing.T) {
+	// Two "blocks" edges seen from LIN-100:
+	//   rel-1 (forward):  LIN-100 blocks LIN-200
+	//   rel-2 (inverse):  LIN-300 blocks LIN-100
+	// So LIN-100 should read as "blocks LIN-200" and "blocked by LIN-300",
+	// each naming the counterpart rather than LIN-100 itself.
+	body := `{"data":{"issue":{
+		"relations":{"nodes":[
+			{"id":"rel-1","type":"blocks","issue":{"id":"uuid-100","identifier":"LIN-100","title":"This issue"},"relatedIssue":{"id":"uuid-200","identifier":"LIN-200","title":"Blocked task"}}
+		]},
+		"inverseRelations":{"nodes":[
+			{"id":"rel-2","type":"blocks","issue":{"id":"uuid-300","identifier":"LIN-300","title":"Blocker task"},"relatedIssue":{"id":"uuid-100","identifier":"LIN-100","title":"This issue"}}
+		]}
+	}}}`
+
+	got := runRelationList(t, "LIN-100", body)
+
+	// Forward "blocks" relation: the queried issue is the blocker.
+	forward := relationLine(t, got, "rel-1")
+	if strings.Contains(forward, "blocked by") || !strings.Contains(forward, "blocks") {
+		t.Fatalf("expected forward blocks relation labeled 'blocks', got:\n%s", forward)
+	}
+	if !strings.Contains(forward, "LIN-200") {
+		t.Fatalf("expected forward relation to name counterpart LIN-200, got:\n%s", forward)
+	}
+
+	// Inverse "blocks" relation: the queried issue is the one being blocked.
+	inverse := relationLine(t, got, "rel-2")
+	if !strings.Contains(inverse, "blocked by") {
+		t.Fatalf("expected inverse blocks relation labeled 'blocked by', got:\n%s", inverse)
+	}
+	if !strings.Contains(inverse, "LIN-300") {
+		t.Fatalf("expected inverse relation to name counterpart LIN-300, got:\n%s", inverse)
+	}
+	// Regression: the counterpart must never be the issue that was queried.
+	if strings.Contains(inverse, "LIN-100") {
+		t.Fatalf("inverse relation named the queried issue as its own counterpart:\n%s", inverse)
+	}
+}
+
+// TestRelationListDirectionIsSymmetric reads the same edge from both ends and
+// asserts the two views are consistent: opposite labels, each naming the other
+// issue. This is the property that fails when either the label mapping or the
+// counterpart selection is inverted, so it covers both defects at once.
+func TestRelationListDirectionIsSymmetric(t *testing.T) {
+	// The single edge under test: LIN-500 blocks LIN-600.
+	edge := `{"id":"rel-sym","type":"blocks","issue":{"id":"uuid-500","identifier":"LIN-500","title":"Blocker"},"relatedIssue":{"id":"uuid-600","identifier":"LIN-600","title":"Blocked"}}`
+
+	// From LIN-500 (the blocker) the edge arrives via relations.
+	fromBlocker := runRelationList(t, "LIN-500", `{"data":{"issue":{
+		"relations":{"nodes":[`+edge+`]},
+		"inverseRelations":{"nodes":[]}
+	}}}`)
+
+	// From LIN-600 (the blocked) the same edge arrives via inverseRelations.
+	fromBlocked := runRelationList(t, "LIN-600", `{"data":{"issue":{
+		"relations":{"nodes":[]},
+		"inverseRelations":{"nodes":[`+edge+`]}
+	}}}`)
+
+	blockerView := relationLine(t, fromBlocker, "rel-sym")
+	if strings.Contains(blockerView, "blocked by") || !strings.Contains(blockerView, "blocks") {
+		t.Fatalf("blocker should read as 'blocks', got:\n%s", blockerView)
+	}
+	if !strings.Contains(blockerView, "LIN-600") || strings.Contains(blockerView, "LIN-500") {
+		t.Fatalf("blocker view should name LIN-600 and not itself, got:\n%s", blockerView)
+	}
+
+	blockedView := relationLine(t, fromBlocked, "rel-sym")
+	if !strings.Contains(blockedView, "blocked by") {
+		t.Fatalf("blocked issue should read as 'blocked by', got:\n%s", blockedView)
+	}
+	if !strings.Contains(blockedView, "LIN-500") || strings.Contains(blockedView, "LIN-600") {
+		t.Fatalf("blocked view should name LIN-500 and not itself, got:\n%s", blockedView)
+	}
+}
+
+func TestRelationOtherIssue(t *testing.T) {
+	source := &api.Issue{ID: "uuid-1", Identifier: "LIN-1", Title: "Source"}
+	target := &api.Issue{ID: "uuid-2", Identifier: "LIN-2", Title: "Target"}
+
+	cases := []struct {
+		name string
+		rel  api.IssueRelation
+		want string
+	}{
+		{
+			// Queried issue is Issue, so the counterpart is RelatedIssue.
+			name: "forward returns related issue",
+			rel:  api.IssueRelation{Issue: source, RelatedIssue: target},
+			want: "LIN-2",
+		},
+		{
+			// Queried issue is RelatedIssue, so the counterpart is Issue.
+			// Both sides are populated — the query selects both on both edges —
+			// so this only works if Inverse is honoured.
+			name: "inverse returns source issue",
+			rel:  api.IssueRelation{Issue: source, RelatedIssue: target, Inverse: true},
+			want: "LIN-1",
+		},
+		{
+			name: "forward falls back to issue when related is nil",
+			rel:  api.IssueRelation{Issue: source},
+			want: "LIN-1",
+		},
+		{
+			name: "inverse falls back to related when issue is nil",
+			rel:  api.IssueRelation{RelatedIssue: target, Inverse: true},
+			want: "LIN-2",
+		},
+		{
+			name: "both nil yields placeholder",
+			rel:  api.IssueRelation{},
+			want: "?",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := relationOtherIssue(&tc.rel); got.Identifier != tc.want {
+				t.Fatalf("relationOtherIssue() = %q, want %q", got.Identifier, tc.want)
+			}
+		})
 	}
 }
 
@@ -268,9 +382,10 @@ func TestRelationRemoveSendsDeleteMutation(t *testing.T) {
 }
 
 func TestRelationTypeLabel(t *testing.T) {
-	// Forward (non-inverse) labels
+	// Forward (non-inverse) labels — the queried issue is the subject acting
+	// on the counterpart, so "blocks" and "duplicate of" share one convention.
 	forwardCases := map[string]string{
-		"blocks":    "blocked by",
+		"blocks":    "blocks",
 		"duplicate": "duplicate of",
 		"related":   "related to",
 		"similar":   "similar to",
@@ -284,7 +399,7 @@ func TestRelationTypeLabel(t *testing.T) {
 
 	// Inverse labels — direction-sensitive types should flip
 	inverseCases := map[string]string{
-		"blocks":    "blocks",
+		"blocks":    "blocked by",
 		"duplicate": "has duplicate",
 		"related":   "related to",
 		"similar":   "similar to",

--- a/master_api_ref.md
+++ b/master_api_ref.md
@@ -143,6 +143,43 @@ mutation IssueUpdate($id: String!, $input: IssueUpdateInput!) {
 }
 ```
 
+### Issue relations
+- `IssueRelationType` enum: `blocks`, `duplicate`, `related`, `similar`.
+  (`blocked_by` is **not** an API type — it is a CLI convenience that maps to
+  `blocks` with the two issue IDs swapped.)
+- Relations are **directional**, and the direction is the field most often read
+  backwards. Per the schema descriptions (verify via introspection, see §2):
+  - `IssueRelation.issue` — *"The source issue whose relationship is being
+    described. This is the issue from which the relation originates."*
+  - `IssueRelation.relatedIssue` — *"The target issue that the source issue is
+    related to. The relation type describes how the source issue relates to this
+    issue."*
+- So for `type: "blocks"`, **`issue` blocks `relatedIssue`** — `issue` is the
+  blocker, `relatedIssue` is the one that must wait. The same source-acts-on-
+  target convention applies to `duplicate` (`issue` is a duplicate of
+  `relatedIssue`).
+- An issue's `relations` connection holds edges where it is the source;
+  `inverseRelations` holds edges where it is the target. To render a direction-
+  aware label you need both, plus a flag recording which connection each edge
+  came from — the counterpart is `relatedIssue` for forward edges and `issue`
+  for inverse ones.
+- `IssueRelationCreateInput` takes `issueId`, `relatedIssueId`, `type`. Both ID
+  fields accept a UUID or an issue identifier (e.g. `LIN-123`).
+
+```graphql
+mutation IssueRelationCreate($input: IssueRelationCreateInput!) {
+  issueRelationCreate(input: $input) {
+    success
+    issueRelation {
+      id
+      type
+      issue { id identifier }
+      relatedIssue { id identifier }
+    }
+  }
+}
+```
+
 ### Projects + milestones
 - List/get/create/update/archive/delete projects
 - Manage lead, state, target dates, teams

--- a/pkg/api/queries.go
+++ b/pkg/api/queries.go
@@ -2405,10 +2405,11 @@ func (c *Client) CreateAttachment(ctx context.Context, input map[string]interfac
 }
 
 // CreateIssueRelation creates a relation between two issues.
-// issueID is the issue to add the relation to.
-// relatedIssueID is the other issue in the relation.
-// relationType is one of: "blocks", "duplicate", "related".
-// For "blocks": issueID is blocked by relatedIssueID.
+// issueID is the source issue the relation originates from.
+// relatedIssueID is the target issue the source relates to.
+// relationType is one of: "blocks", "duplicate", "related", "similar".
+// The type describes how the source relates to the target, so for "blocks":
+// issueID blocks relatedIssueID.
 func (c *Client) CreateIssueRelation(ctx context.Context, issueID, relatedIssueID, relationType string) (*IssueRelation, error) {
 	query := `
 		mutation IssueRelationCreate($input: IssueRelationCreateInput!) {


### PR DESCRIPTION
`issue relation list` labels blocking relations backwards, and names the queried issue as its own counterpart for inverse relations. `relation add` stores the opposite relation from the one requested, while printing the direction you asked for.

Fixes #57 (thanks @jumpalongjim for the report and the diagnosis — this implements the fix proposed there).

## The internal inconsistency

The clearest symptom needs no external ground truth. In `relationTypeLabel`, the `blocks` case contradicts the `duplicate` case directly beside it:

```go
case "blocks":
	if inverse {
		return "blocks"
	}
	return "blocked by"     // queried issue is the source — it BLOCKS
case "duplicate":
	if inverse {
		return "has duplicate"
	}
	return "duplicate of"   // queried issue is the source — correct
```

`duplicate` describes the *queried* issue as the subject acting on the counterpart. Under that same convention, non-inverse `blocks` must be `"blocks"`. The two returns are swapped.

## Root cause

One comment, in `cmd/relation.go`:

```go
//   type = "blocks" means issueId is blocked by relatedIssueId
```

That premise is backwards, and every direction decision downstream inherits it. Per Linear's schema (`__type(name: "IssueRelation")`):

- `issue` — *"The **source** issue whose relationship is being described. This is the issue from which the relation originates."*
- `relatedIssue` — *"The target issue that the source issue is related to. The relation type describes **how the source issue relates to this issue**."*

So for `type: "blocks"`, `issue` blocks `relatedIssue`.

## What users see

For a single edge where `A` blocks `B`:

| Queried from | before | after |
|---|---|---|
| `A` (the blocker) | `blocked by  B` | `blocks  B` |
| `B` (the blocked) | `blocks  B` | `blocked by  A` |

Note the asymmetry that let this survive: querying `B` produces a self-referential line that reads as a cosmetic rendering quirk and gets skimmed past, while querying `A` produces a perfectly grammatical, actionable line that is simply false. Because `relation add` was inverted from the same premise, writing and reading through the CLI partially cancelled out — the bug only disagreed with the Linear web UI.

`issue get` was already rendering `"blocks"` → `"Blocks"` (`cmd/issue.go`), so the two commands have been contradicting each other, with `issue get` correct. Left untouched here to keep the diff focused; its other gaps (a dead `"blocked"` case that is not a Linear enum value, and ignoring `inverseRelations`) are worth a separate issue.

## Changes

- **`relation add`** — `--blocks` no longer swaps the IDs; `--blocked-by` now does. `related` / `duplicate` / `similar` are untouched, as they were already correct.
- **`relationTypeLabel`** — the two `blocks` returns are swapped.
- **`relationOtherIssue`** — now selects the counterpart on `rel.Inverse` rather than on which field happens to be populated. The query selects both `issue` and `relatedIssue` on both `relations` and `inverseRelations`, so `RelatedIssue` is never nil and the old unconditional preference always returned the issue the caller asked about. Nil-guards are kept as fallbacks.
- The root-cause comment and the `CreateIssueRelation` doc comment, which carried the same inverted claim.
- Docs: README relation section gains an explicit direction note; `master_api_ref.md` gains an issue-relations subsection with the schema descriptions, so the next reader has the citation; CHANGELOG entry including a note for users whose relations were written through the inverted path.

## About the tests

**The existing tests asserted the inverted behaviour** — all four of them — which is why this survived. They are corrected here, not weakened. Flagging that explicitly so the diff does not read the wrong way.

Added coverage the suite lacked:

- `TestRelationOtherIssue` — table test including an inverse row with **both** `Issue` and `RelatedIssue` populated, which is the real-world shape and the case that was silently broken. Nothing covered this before.
- `TestRelationListDirectionIsSymmetric` — reads the same edge from both ends and asserts opposite labels, each naming the *other* issue. This is the property that actually failed, and it catches all three defects at once.

Both new tests fail on `master` and pass with this change; I verified that by reverting the source files and re-running them.

## Verification

`go test ./...` passes. Beyond the unit tests, I ran a live round-trip against the API on throwaway issues (created and deleted afterwards), verifying the stored direction via **raw GraphQL** rather than through the CLI, since reading back through the CLI would cancel the error out:

```
$ linctl issue relation add A --blocks B
$ # raw GraphQL:
  relations: A --blocks--> B          # correct; before this change it stored B --blocks--> A

$ linctl issue relation add A --blocked-by B
$ # raw GraphQL:
  inverseRelations: B --blocks--> A   # correct

$ linctl issue relation list A -p
  blocked by   B
$ linctl issue relation list B -p
  blocks       A
```

The read path was also checked against a pre-existing edge confirmed correct in the web UI.

## Risk note on the write path

This is the part worth your judgement rather than mine. `relation add --blocks` has been storing the inverse since the feature landed in #41, so **any blocking relation created through linctl is currently backwards in Linear**. This change corrects future writes, which means their meaning shifts relative to existing data. Users who built dependency graphs through the CLI will find old and new edges disagree.

I have not attempted any migration — detecting which existing relations came from linctl versus the web UI isn't possible from the data, so that call is yours. Options include shipping as-is with the CHANGELOG note, or splitting the write-path fix into its own release with louder messaging. Happy to restructure this into read-path-only plus a follow-up if you'd prefer to land the safe half first.
